### PR TITLE
fix(tauri.conf): 🐛 update updater endpoint URL

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
 	"plugins": {
 		"updater": {
 			"endpoints": [
-				"https://github.com/lovelesscodes/storyforge/releases/latest/download/latest.json"
+				"https://github.com/lovelesscodes/storyforge/releases/download/latest/latest.json"
 			],
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGMEI3NzE4QkNBOTUxNTUKUldSVlVhbThHSGNMais2dzluVDdrQTJ1WWg5M3laWnlYVlNuZ09lMGluU1h1L0RRVnNvTjBhM08K"
 		}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -57,6 +57,8 @@ function RootComponent() {
 						}),
 				},
 				description: `Version ${update.version} is available.`,
+				dismissible: true,
+				duration: Number.POSITIVE_INFINITY,
 				id: "updater",
 			});
 		}


### PR DESCRIPTION
* Corrected the URL for the updater endpoint in `tauri.conf.json`.
* Ensured the updater functionality points to the correct release path.