### PR TITLE
chore(publish): 🔧 update git push command for version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git push origin HEAD:releases
+          git push origin releases
 
   publish-tauri:
     needs: update-version


### PR DESCRIPTION
* Changed the git push command to push to the `releases` branch directly.
* This simplifies the command and ensures the correct branch is targeted.