### PR TITLE
chore(publish): 🔧 update git push command to 'release'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git push origin releases
+          git push origin release
 
   publish-tauri:
     needs: update-version


### PR DESCRIPTION
* Changed the git push command from 'releases' to 'release' for consistency.
* Ensures the correct branch is targeted during the version bump process.