### PR TITLE
chore(publish): 🔧 update tag format to 'storyforge-vX.Y.Z'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "storyforge-v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   update-version:
@@ -23,11 +23,11 @@ jobs:
         id: bump_version
         run: |
           # Get the new version from the tag that triggered the workflow
-          if [[ "${GITHUB_REF}" =~ refs/tags/v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          if [[ "${GITHUB_REF}" =~ refs/tags/storyforge-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             NEW_VERSION="${BASH_REMATCH[1]}"
             echo "New version from tag: $NEW_VERSION"
           else
-            echo "Error: This workflow must be triggered by a tag in the format vX.Y.Z"
+            echo "Error: This workflow must be triggered by a tag in the format storyforge-vX.Y.Z"
             exit 1
           fi
 
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git push origin release
+          git push origin HEAD:release
 
   publish-tauri:
     needs: update-version


### PR DESCRIPTION
* Changed the tag format in the workflow to match 'storyforge-v[0-9]+.[0-9]+.[0-9]+'.
* Updated the version bump script to reflect the new tag format.
* Adjusted the error message for incorrect tag formats.
* Modified the git push command to push to the 'release' branch.