### PR TITLE
chore: 🔧 bump version to $NEW_VERSION

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
-          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git commit -m "chore: bump version to $NEW_VERSION"
           TAG="storyforge-v$NEW_VERSION"
           git tag -f "$TAG"
           git push origin HEAD:release


### PR DESCRIPTION
* Removed [skip ci] from the commit message to ensure CI runs on version bump.