### PR TITLE
chore(funding): 📝 update GitHub funding link to LovelessCodes

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [better-auth]
+github: [lovelesscodes]


### PR DESCRIPTION
* Changed funding link from `better-auth` to `lovelesscodes`.
* Ensures correct attribution for project support.