### PR TITLE
chore: 🔧 remove annotated tag creation from version bump workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -60,10 +60,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          # Create an annotated tag that the second workflow listens to
-          TAG="storyforge-v$NEW_VERSION"
-          git tag -a "$TAG" -m "Release $TAG"
-
-          # Push the branch and the tag
           git push origin HEAD:release
-          git push origin "$TAG"


### PR DESCRIPTION
* Eliminated the creation and pushing of an annotated tag during the version bump process.
* Simplified the workflow to only push the release branch.