### PR TITLE
fix(dialogs): 🐛 handle undefined icon in EditInstallationDialog

### DIFF
--- a/src/components/dialogs/editinstallation.dialog.tsx
+++ b/src/components/dialogs/editinstallation.dialog.tsx
@@ -131,7 +131,7 @@ export function EditInstallationDialog({
 	const form = useForm({
 		defaultValues: {
 			favorite: installation.favorite,
-			icon: installation.icon,
+			icon: installation.icon ?? "",
 			id: installation.id,
 			index: installation.index,
 			name: installation.name,

--- a/src/components/sidebars/app.sidebar.tsx
+++ b/src/components/sidebars/app.sidebar.tsx
@@ -226,20 +226,6 @@ export function AppSidebar() {
 									activeProps={{
 										className: "bg-accent text-accent-foreground",
 									}}
-									to="/news"
-									viewTransition={{ types: ["warp"] }}
-								>
-									<NewspaperIcon />
-									News
-								</Link>
-							</SidebarMenuButton>
-						</SidebarMenuItem>
-						<SidebarMenuItem>
-							<SidebarMenuButton asChild>
-								<Link
-									activeProps={{
-										className: "bg-accent text-accent-foreground",
-									}}
 									to="/installations"
 									viewTransition={{ types: ["warp"] }}
 								>
@@ -316,6 +302,20 @@ export function AppSidebar() {
 							<SidebarMenuBadge className="text-xs text-muted-foreground">
 								{installedVersions?.length}
 							</SidebarMenuBadge>
+						</SidebarMenuItem>
+						<SidebarMenuItem>
+							<SidebarMenuButton asChild>
+								<Link
+									activeProps={{
+										className: "bg-accent text-accent-foreground",
+									}}
+									to="/news"
+									viewTransition={{ types: ["warp"] }}
+								>
+									<NewspaperIcon />
+									News
+								</Link>
+							</SidebarMenuButton>
 						</SidebarMenuItem>
 					</SidebarMenu>
 				</SidebarGroup>


### PR DESCRIPTION
* Ensure `icon` defaults to an empty string if `installation.icon` is undefined.
* Improves robustness of the form handling in the dialog component.