### PR TITLE
fix(lib): ✨ set environment variable for WebKit compositing mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())


### PR DESCRIPTION
* Added `WEBKIT_DISABLE_COMPOSITING_MODE` environment variable to improve rendering performance.