### PR TITLE
feat(search): ✨ add keyboard shortcut for focusing search input

### DIFF
--- a/src/components/inputs/search.input.tsx
+++ b/src/components/inputs/search.input.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
-import { forwardRef, useId } from "react";
+import { forwardRef, useEffect, useId, useRef } from "react";
 import { Input } from "@/components/ui/input";
+import { modifierLabel } from "@/lib/utils";
 
 type SearchInputProps = {
 	className?: string | ((active: boolean) => string);
@@ -9,19 +10,41 @@ type SearchInputProps = {
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 	({ className, ...rest }, ref) => {
 		const id = useId();
+		const searchRef = useRef<HTMLInputElement>(null);
+		useEffect(() => {
+			// Add a keyboard shortcut to focus the search input
+			// This will listen for the "⌘K" key combination and focus the input
+			const handleKeyDown = (event: KeyboardEvent) => {
+				if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+					event.preventDefault();
+					searchRef.current?.focus();
+				}
+			};
+			window.addEventListener("keydown", handleKeyDown);
+			return () => {
+				window.removeEventListener("keydown", handleKeyDown);
+			};
+		}, []);
 		return (
 			<div className="relative">
 				<Input
 					className={clsx(["pe-11", className])}
 					id={id}
 					placeholder="Search..."
-					ref={ref}
+					ref={(el) => {
+						searchRef.current = el;
+						if (typeof ref === "function") {
+							ref(el);
+						} else if (ref) {
+							ref.current = el;
+						}
+					}}
 					type="search"
 					{...rest}
 				/>
 				<div className="text-muted-foreground pointer-events-none absolute inset-y-0 end-0 flex items-center justify-center pe-2">
 					<kbd className="text-muted-foreground/70 inline-flex h-5 max-h-full items-center rounded border px-1 font-[inherit] text-[0.625rem] font-medium">
-						⌘K
+						{modifierLabel}K
 					</kbd>
 				</div>
 			</div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -46,3 +46,9 @@ export const zipfolderprefix = () => {
 	if (pf === "m") return "*.app/";
 	return "";
 };
+
+export const isMac =
+	navigator.platform.includes("Mac") ||
+	/Macintosh|MacIntel|MacPPC|Mac68K/.test(navigator.userAgent);
+
+export const modifierLabel = isMac ? "⌘" : "Ctrl+";


### PR DESCRIPTION
* Implemented a keyboard shortcut using "⌘K" (or "Ctrl+K") to focus the search input.
* Refactored the ref handling to ensure proper focus management.
* Introduced `modifierLabel` utility to dynamically display the correct modifier key based on the platform.