### PR TITLE
Revamp the Add Mod UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feedback on connecting to a server
 - [Code of conduct](/CODE_OF_CONDUCT.md) adapted from [Contributor Covenant](https://www.contributor-covenant.org/) 
 - [Contributing document](./CONTRIBUTING.md) to help new contributors
+- "Any" side filtering on mods page
+- Labels added to selects/dropdowns on mods page
 
 ### Fixed
 

--- a/src/components/comboboxes/author.combobox.tsx
+++ b/src/components/comboboxes/author.combobox.tsx
@@ -17,6 +17,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 
 type AuthorResponse = {
 	[key: string]: string;
@@ -50,11 +51,20 @@ export const AuthorCombobox = (
 	);
 
 	return (
-		<Popover onOpenChange={setOpen} open={open}>
+		<Popover
+			onOpenChange={(v) => {
+				setOpen(v);
+				setSearch("");
+			}}
+			open={open}
+		>
 			<PopoverTrigger asChild>
 				<Button
 					aria-expanded={open}
-					className="w-[200px] justify-between relative cursor-text"
+					className={cn(
+						"w-[200px] justify-between relative cursor-text",
+						actualValue ? "text-foreground" : "text-muted-foreground",
+					)}
 					role="combobox"
 					variant="outline"
 				>

--- a/src/components/comboboxes/author.combobox.tsx
+++ b/src/components/comboboxes/author.combobox.tsx
@@ -68,6 +68,9 @@ export const AuthorCombobox = (
 					role="combobox"
 					variant="outline"
 				>
+					<span className="top-0 px-2 start-1 text-xs z-10 block -translate-y-1/2 absolute inline-flex text-muted-foreground pointer-events-none bg-background">
+						Author
+					</span>
 					{actualValue ? actualValue : "Select author..."}
 
 					{actualValue ? (

--- a/src/components/lists/mod.list.tsx
+++ b/src/components/lists/mod.list.tsx
@@ -95,7 +95,9 @@ export function ModList({
 		?.filter((mod) => mod.type === category)
 		?.filter((mod) =>
 			side !== "installed"
-				? mod.side === side
+				? side === "any"
+					? true
+					: mod.side === side
 				: installedMods.some(
 						(installedMod) =>
 							installedMod.modid === mod.modid ||

--- a/src/components/toggle-groups/side.toggle-group.tsx
+++ b/src/components/toggle-groups/side.toggle-group.tsx
@@ -6,21 +6,24 @@ export default function SideToggleGroup() {
 
 	return (
 		<ToggleGroup
-			className="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-9 has-[>svg]:px-3 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 w-[300px] justify-between relative"
+			className="inline-flex items-center whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-9 has-[>svg]:px-3 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 w-[350px] justify-between relative"
 			onValueChange={(value: ModsFilters["side"]) => {
 				if (value) setSide(value);
 			}}
 			type="single"
 			value={side}
 		>
-			<ToggleGroupItem aria-label="Both" value="both">
-				Both
+			<ToggleGroupItem aria-label="Any" value="any">
+				Any
 			</ToggleGroupItem>
 			<ToggleGroupItem aria-label="Client" value="client">
 				Client
 			</ToggleGroupItem>
 			<ToggleGroupItem aria-label="Server" value="server">
 				Server
+			</ToggleGroupItem>
+			<ToggleGroupItem aria-label="Both" value="both">
+				Both
 			</ToggleGroupItem>
 			<ToggleGroupItem aria-label="Installed" value="installed">
 				Installed

--- a/src/routes/install-mods/$id.tsx
+++ b/src/routes/install-mods/$id.tsx
@@ -117,7 +117,7 @@ function RouteComponent() {
 							className={cn(
 								"pointer-events-none absolute start-1 z-10 block -translate-y-1/2 inline-flex text-muted-foreground px-2 transition-all",
 								selectedGameVersions.length > 0
-									? "top-0 bg-background"
+									? "top-0 bg-background text-xs"
 									: "top-1/2 bg-transparent",
 							)}
 						>
@@ -162,7 +162,7 @@ function RouteComponent() {
 							className={cn(
 								"pointer-events-none absolute start-1 z-10 block -translate-y-1/2 inline-flex text-muted-foreground px-2 transition-all",
 								selectedModTags.length > 0
-									? "top-0 bg-background"
+									? "top-0 bg-background text-xs"
 									: "top-1/2 bg-transparent",
 							)}
 						>

--- a/src/routes/install-mods/$id.tsx
+++ b/src/routes/install-mods/$id.tsx
@@ -14,6 +14,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ErrorComponent } from "@/components/ui/error";
+import { Label } from "@/components/ui/label";
 import {
 	Select,
 	SelectContent,
@@ -22,7 +23,7 @@ import {
 } from "@/components/ui/select";
 import { useInstalledMods } from "@/hooks/use-installed-mods";
 import { gameVersionsQuery, modTagsQuery } from "@/lib/queries";
-import { compareSemverDesc } from "@/lib/utils";
+import { cn, compareSemverDesc } from "@/lib/utils";
 import { useInstallations } from "@/stores/installations";
 import { type ModsFilters, useModsFilters } from "@/stores/modsFilters";
 
@@ -104,12 +105,29 @@ function RouteComponent() {
 					value={searchText}
 				/>
 				<DropdownMenu>
-					<DropdownMenuTrigger className="flex gap-1 w-46 truncate">
+					<DropdownMenuTrigger
+						className={cn(
+							"flex gap-1 w-46 relative",
+							selectedGameVersions.length > 0
+								? "text-foreground"
+								: "text-transparent",
+						)}
+					>
+						<span
+							className={cn(
+								"pointer-events-none absolute start-1 z-10 block -translate-y-1/2 inline-flex text-muted-foreground px-2 transition-all",
+								selectedGameVersions.length > 0
+									? "top-0 bg-background"
+									: "top-1/2 bg-transparent",
+							)}
+						>
+							Game Version(s)
+						</span>
 						{selectedGameVersions.length > 0
 							? selectedGameVersions.length > 1
 								? `${selectedGameVersions.length} versions`
 								: selectedGameVersions[0]
-							: "Game version(s)"}
+							: "-"}
 						<ChevronDownIcon className="size-4 opacity-50" />
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="start">
@@ -132,12 +150,29 @@ function RouteComponent() {
 					</DropdownMenuContent>
 				</DropdownMenu>
 				<DropdownMenu>
-					<DropdownMenuTrigger className="w-46 flex gap-1 truncate">
+					<DropdownMenuTrigger
+						className={cn(
+							"w-46 flex gap-1 relative",
+							selectedModTags.length > 0
+								? "text-foreground"
+								: "text-transparent",
+						)}
+					>
+						<span
+							className={cn(
+								"pointer-events-none absolute start-1 z-10 block -translate-y-1/2 inline-flex text-muted-foreground px-2 transition-all",
+								selectedModTags.length > 0
+									? "top-0 bg-background"
+									: "top-1/2 bg-transparent",
+							)}
+						>
+							Mod Tag(s)
+						</span>
 						{selectedModTags.length > 0
 							? selectedModTags.length > 1
 								? `${selectedModTags.length} tags`
 								: selectedModTags[0].name
-							: "Mod tag(s)"}
+							: "-"}
 						<ChevronDownIcon className="size-4 opacity-50" />
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="start">
@@ -163,42 +198,52 @@ function RouteComponent() {
 							))}
 					</DropdownMenuContent>
 				</DropdownMenu>
-				<Select
-					onValueChange={(value) => setSortBy(value as ModsFilters["sortBy"])}
-					value={sortBy}
-				>
-					<SelectTrigger>
-						{sortBy
-							? `${sortOptions[sortBy as keyof typeof sortOptions]}`
-							: "Sort by"}
-					</SelectTrigger>
-					<SelectContent align="start">
-						{Object.entries(sortOptions).map(([key, value]) => (
-							<SelectItem key={key} value={key}>
-								{value}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-				<Select
-					onValueChange={(value) =>
-						setCategory(value as ModsFilters["category"])
-					}
-					value={category}
-				>
-					<SelectTrigger>
-						{category
-							? `${categoryOptions[category as keyof typeof categoryOptions]}`
-							: "Category"}
-					</SelectTrigger>
-					<SelectContent align="start">
-						{Object.entries(categoryOptions).map(([key, value]) => (
-							<SelectItem key={key} value={key}>
-								{value}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+				<div className="group relative">
+					<Label className="bg-background text-muted-foreground pointer-events-none absolute start-1 top-0 z-10 block -translate-y-1/2 px-2 text-xs font-medium group-has-disabled:opacity-50">
+						Sort by
+					</Label>
+					<Select
+						onValueChange={(value) => setSortBy(value as ModsFilters["sortBy"])}
+						value={sortBy}
+					>
+						<SelectTrigger>
+							{sortBy
+								? `${sortOptions[sortBy as keyof typeof sortOptions]}`
+								: "Sort by"}
+						</SelectTrigger>
+						<SelectContent align="start">
+							{Object.entries(sortOptions).map(([key, value]) => (
+								<SelectItem key={key} value={key}>
+									{value}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className="group relative">
+					<Label className="bg-background text-muted-foreground pointer-events-none absolute start-1 top-0 z-10 block -translate-y-1/2 px-2 text-xs font-medium group-has-disabled:opacity-50">
+						Category
+					</Label>
+					<Select
+						onValueChange={(value) =>
+							setCategory(value as ModsFilters["category"])
+						}
+						value={category}
+					>
+						<SelectTrigger>
+							{category
+								? `${categoryOptions[category as keyof typeof categoryOptions]}`
+								: "Category"}
+						</SelectTrigger>
+						<SelectContent align="start">
+							{Object.entries(categoryOptions).map(([key, value]) => (
+								<SelectItem key={key} value={key}>
+									{value}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
 				<TextSwitch
 					checked={orderDirection === "descending"}
 					onCheckedChange={(checked) =>

--- a/src/stores/modsFilters.ts
+++ b/src/stores/modsFilters.ts
@@ -25,7 +25,7 @@ export type ModsFilters = {
 	setOrderDirection: (direction: ModsFilters["orderDirection"]) => void;
 	author: string;
 	setAuthor: (author: ModsFilters["author"]) => void;
-	side: "client" | "server" | "both" | "installed";
+	side: "any" | "client" | "server" | "both" | "installed";
 	setSide: (side: ModsFilters["side"]) => void;
 	category: "mod" | "externaltool" | "other";
 	setCategory: (category: ModsFilters["category"]) => void;
@@ -65,6 +65,6 @@ export const useModsFilters = create<ModsFilters>()((set) => ({
 	setSearchText: (text) => set({ searchText: text }),
 	setSide: (side) => set({ side }),
 	setSortBy: (key) => set({ sortBy: key }),
-	side: "both",
+	side: "any",
 	sortBy: "trending",
 }));


### PR DESCRIPTION
## Summary
Adds a way better user experience in the Add Mod page by describing what each filter does.

## Changes
- Adds Game versions label to the game version select on the Add Mod page
- Adds Mod tags label to the mod tags select on the Add Mod page
- Adds an Any filtering for the side filtering on the Add Mod page
- Adds Author label to the author combo box on the Add Mod page
- Adds Sort by label to the sort by select on the Add Mod page
- Adds Category label to the category select on the Add Mod page

## Screenshots / Demos (if applicable)
Before:
<img width="1696" height="1060" alt="image" src="https://github.com/user-attachments/assets/5ca55193-d215-4e3b-a9a8-aebae74fb4ce" />

After:
<img width="1696" height="1050" alt="image" src="https://github.com/user-attachments/assets/93adf384-3ad1-4ac7-9662-0eeddb0fde42" />

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Additional Context
- Any side filtering requested by Discord user Groblockia_