### PR TITLE
fix: resolve issues with world loading and installation paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved warnings during the build process.
 - Resolve db-wal and db-shm issue on world rename.
 - Fixed an issue where the game would not load a world if done through the launcher on windows.
+- Fixed an issue where the documents folder would be opened instead of the installation folder on windows.
+- Fixed an issue where, after deleting a version, reinstalling the same version would throw an error.
 
 ### Changed
 

--- a/src-tauri/src/modules/download.rs
+++ b/src-tauri/src/modules/download.rs
@@ -38,6 +38,36 @@ pub async fn download_and_maybe_extract<R: Runtime>(
     // Use "" or None to extract all
     zipsubfolderprefix: Option<String>,
 ) -> Result<String, UiError> {
+    let destpath = PathBuf::from(&destpath);
+    
+    // Check if already installed (has vintagestory executable)
+    if extract && destpath.exists() {
+        let mut already_installed = false;
+        for entry in walkdir::WalkDir::new(&destpath) {
+            if let Ok(entry) = entry {
+                if entry.file_type().is_file() {
+                    let fname = entry.file_name().to_string_lossy();
+                    if fname.eq_ignore_ascii_case("vintagestory")
+                        || fname.eq_ignore_ascii_case("vintagestory.exe")
+                    {
+                        already_installed = true;
+                        break;
+                    }
+                }
+            }
+        }
+        
+        if already_installed {
+            eprintln!("Version already downloaded at: {:?}", destpath);
+            return Ok("already_downloaded".into());
+        } else {
+            // Directory exists but no exe found - clean up partial installation
+            eprintln!("Cleaning up incomplete installation at: {:?}", destpath);
+            fs::remove_dir_all(&destpath)
+                .map_err(|e| UiError::from(format!("Failed to clean up incomplete installation: {e}")))?;
+        }
+    }
+    
     // 1) Download
     let resp = get(&url).await.map_err(|e| format!("request error: {e}"))?;
 
@@ -74,7 +104,6 @@ pub async fn download_and_maybe_extract<R: Runtime>(
         return Err(UiError::from(format!("HTTP error: {}", resp.status())));
     }
 
-    let destpath = PathBuf::from(&destpath);
     if !destpath.exists() {
         fs::create_dir_all(&destpath)
             .map_err(|e| UiError::from(format!("create dir error: {e}")))?;

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -310,32 +310,79 @@ pub fn play_game(app: AppHandle, options: Option<PlayGameParams>) -> Result<Stri
 pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
     let path = Path::new(&path);
 
+    // Add diagnostic logging
+    eprintln!("reveal_in_file_explorer called with path: {:?}", path);
+    eprintln!("Path exists: {}", path.exists());
+    eprintln!("Path is_file: {}", path.is_file());
+    eprintln!("Path is_dir: {}", path.is_dir());
+
     if cfg!(target_os = "windows") {
-        // If it's a file, use /select, to highlight it. If it's a dir, just open it.
+        // Validate path exists, create directory if needed
+        if !path.exists() {
+            // If path doesn't exist, it should be a directory - create it
+            std::fs::create_dir_all(path).map_err(|e| UiError {
+                name: "create_dir_failed".into(),
+                message: format!("Failed to create directory: {e}"),
+            })?;
+            eprintln!("Created directory: {:?}", path);
+        }
+        
+        // Now that we've ensured the path exists, open it
         if path.is_file() {
+            // If it's a file, use /select to highlight it
             Command::new("explorer")
                 .args(["/select,", &path.as_os_str().to_string_lossy()])
                 .status()
                 .map_err(|e| UiError::from(format!("Failed to open explorer: {e}")))?;
-        } else {
+        } else if path.is_dir() {
+            // If it's a directory, just open it
             Command::new("explorer")
                 .arg(path.as_os_str().to_string_lossy().into_owned())
                 .status()
                 .map_err(|e| UiError::from(format!("Failed to open explorer: {e}")))?;
+        } else {
+            // This shouldn't happen after we created the directory, but handle it anyway
+            return Err(UiError {
+                name: "invalid_path".into(),
+                message: format!("Path is neither a file nor directory: {}", path.display()),
+            });
         }
     } else if cfg!(target_os = "macos") {
+        // Validate path exists, create directory if needed
+        if !path.exists() {
+            std::fs::create_dir_all(path).map_err(|e| UiError {
+                name: "create_dir_failed".into(),
+                message: format!("Failed to create directory: {e}"),
+            })?;
+            eprintln!("Created directory: {:?}", path);
+        }
+        
         if path.is_dir() {
             Command::new("open")
                 .arg(&path.as_os_str())
                 .status()
                 .map_err(|e| UiError::from(format!("Failed to open Finder: {e}")))?;
-        } else {
+        } else if path.is_file() {
             Command::new("open")
                 .args(["-R", &path.as_os_str().to_string_lossy()])
                 .status()
                 .map_err(|e| UiError::from(format!("Failed to open Finder: {e}")))?;
+        } else {
+            return Err(UiError {
+                name: "invalid_path".into(),
+                message: format!("Path is neither a file nor directory: {}", path.display()),
+            });
         }
     } else if cfg!(target_os = "linux") {
+        // Validate path exists, create directory if needed
+        if !path.exists() {
+            std::fs::create_dir_all(path).map_err(|e| UiError {
+                name: "create_dir_failed".into(),
+                message: format!("Failed to create directory: {e}"),
+            })?;
+            eprintln!("Created directory: {:?}", path);
+        }
+        
         // Try xdg-open for general desktops.
         // For files, most DEs open the default app; to "reveal", try the folder.
         let target = if path.is_file() {


### PR DESCRIPTION
## Summary
- Fixed an issue where the documents folder would be opened instead of the installation folder on windows.
- Fixed an issue where, after deleting a version, reinstalling the same version would throw an error.

## Changes
- Both errors were not reliably reproducible, so the most likely fixes were applied. There may be edge-cases remaining to be fixed.

## Related Issues
- Fixes #80<number>

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Reviewers
- @LovelessCodes 