### PR TITLE
Add stream mode, dark mode toggle & input for installations/versions path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Contributing document](./CONTRIBUTING.md) to help new contributors.
 - "Any" side filtering on mods page.
 - Labels added to selects/dropdowns on mods page.
+- Ability to change theme.
+- Ability to enable stream mode to hide server ip addresses.
+- Ability to change where versions and installation folders are stored.
 
 ### Fixed
 
@@ -28,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve db-wal and db-shm issue on world rename.
 - Resolved Tar issue on some Linux distros
 - Fixed an issue where the game would not load a world if done through the launcher on windows.
+- Fixed issue on windows with _some_ paths on installations and versions.
 
 ### Changed
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@tanstack/react-router-devtools": "^1.131.50",
         "@tanstack/react-virtual": "^3.13.12",
         "@tauri-apps/api": "^2.8.0",
-        "@tauri-apps/plugin-dialog": "~2.4.0",
+        "@tauri-apps/plugin-dialog": "~2",
         "@tauri-apps/plugin-fs": "~2.4.2",
         "@tauri-apps/plugin-opener": "~2",
         "@tauri-apps/plugin-os": "~2.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@tanstack/react-router-devtools": "^1.131.50",
 		"@tanstack/react-virtual": "^3.13.12",
 		"@tauri-apps/api": "^2.8.0",
-		"@tauri-apps/plugin-dialog": "~2.4.0",
+		"@tauri-apps/plugin-dialog": "~2",
 		"@tauri-apps/plugin-fs": "~2.4.2",
 		"@tauri-apps/plugin-opener": "~2",
 		"@tauri-apps/plugin-os": "~2.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7,6 +7,7 @@ name = "StoryForge"
 version = "0.3.6"
 dependencies = [
  "dunce",
+ "fs_extra",
  "futures-util",
  "json5",
  "log",
@@ -1221,6 +1222,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -11,13 +11,14 @@ dependencies = [
  "json5",
  "log",
  "prost",
- "quick-xml",
+ "quick-xml 0.38.3",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
@@ -104,6 +105,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
 ]
 
 [[package]]
@@ -871,6 +893,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.4",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -883,6 +907,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -907,6 +940,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -3262,7 +3301,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.11.4",
- "quick-xml",
+ "quick-xml 0.38.3",
  "serde",
  "time",
 ]
@@ -3419,6 +3458,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3734,6 +3782,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +3996,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4622,6 +4701,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beee42a4002bc695550599b011728d9dfabf82f767f134754ed6655e434824e"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315784ec4be45e90a987687bae7235e6be3d6e9e350d2b75c16b8a4bf22c1db7"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.17",
+ "toml 0.9.7",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,9 +5124,11 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.59.0",
 ]
 
@@ -5561,6 +5682,66 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.2",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+dependencies = [
+ "bitflags 2.9.4",
+ "rustix 1.1.2",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+dependencies = [
+ "bitflags 2.9.4",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.37.5",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -6369,6 +6550,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.60.2",
@@ -6625,6 +6807,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.13",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ tauri-plugin-opener = "2"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 prost = "0.14.1"
 json5 = "0.4.1"
+tauri-plugin-dialog = "2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 prost = "0.14.1"
 json5 = "0.4.1"
 tauri-plugin-dialog = "2"
+fs_extra = "1.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,7 +8,8 @@
 		"os:default",
 		"process:default",
 		"updater:default",
-		"opener:default"
+		"opener:default",
+		"dialog:default"
 	],
 	"windows": ["main"]
 }

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -6,7 +6,8 @@
 		"os:default",
 		"process:default",
 		"updater:default",
-		"opener:default"
+		"opener:default",
+		"dialog:default"
 	],
 	"platforms": ["macOS", "windows", "linux"],
 	"windows": ["main"]

--- a/src-tauri/capabilities/zustand.json
+++ b/src-tauri/capabilities/zustand.json
@@ -6,7 +6,8 @@
 		"os:default",
 		"process:default",
 		"updater:default",
-		"opener:default"
+		"opener:default",
+		"dialog:default"
 	],
 	"windows": ["*"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use tauri::Manager;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,12 +53,14 @@ pub fn run() {
             versions::fetch_versions,
             versions::get_installed_versions,
             versions::remove_installed_version,
+            versions::move_versions_folder,
             // Installations
             installations::play_game,
             installations::confirm_vintage_story_exe,
             installations::initialize_game,
             installations::reveal_in_file_explorer,
             installations::remove_installation,
+            installations::move_installations_folder,
             // Servers
             servers::fetch_public_servers,
             servers::fetch_all_servers,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             versions::get_installed_versions,
             versions::remove_installed_version,
             versions::move_versions_folder,
+            versions::remove_all_versions,
             // Installations
             installations::play_game,
             installations::confirm_vintage_story_exe,
@@ -61,6 +62,7 @@ pub fn run() {
             installations::reveal_in_file_explorer,
             installations::remove_installation,
             installations::move_installations_folder,
+            installations::remove_all_installations,
             // Servers
             servers::fetch_public_servers,
             servers::fetch_all_servers,

--- a/src-tauri/src/modules.rs
+++ b/src-tauri/src/modules.rs
@@ -7,4 +7,5 @@ pub mod news;
 pub mod proto;
 pub mod saves;
 pub mod servers;
+pub mod utils;
 pub mod versions;

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -8,10 +8,11 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use tauri::{command, AppHandle, Emitter, Manager};
+use tauri::{command, AppHandle, Emitter};
 use tauri_plugin_zustand::ManagerExt;
 
 use super::errors::UiError;
+use super::utils::versions_folder;
 
 #[command]
 pub async fn initialize_game(path: String) -> Result<String, UiError> {
@@ -65,10 +66,7 @@ pub fn play_game(app: AppHandle, options: Option<PlayGameParams>) -> Result<Stri
             name: "not_found".into(),
             message: format!("Installation with id {} not found", options.installation_id),
         })?;
-    let version_path = app
-        .path()
-        .app_data_dir()
-        .unwrap()
+    let version_path = versions_folder(app.clone())
         .join("versions")
         .join(installation["version"].as_str().unwrap());
     if !version_path.exists() || !version_path.is_dir() {

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -12,7 +12,7 @@ use tauri::{command, AppHandle, Emitter};
 use tauri_plugin_zustand::ManagerExt;
 
 use super::errors::UiError;
-use super::utils::versions_folder;
+use super::utils::{move_folder, versions_folder};
 
 #[command]
 pub async fn initialize_game(path: String) -> Result<String, UiError> {
@@ -453,27 +453,10 @@ pub async fn move_installations_folder(
     source: String,
     destination: String,
 ) -> Result<String, UiError> {
-    let source_path = std::path::PathBuf::from(source).join("installations");
-    let destination_path = std::path::PathBuf::from(destination).join("installations");
-
-    if !source_path.exists() || !source_path.is_dir() {
-        return Ok("no_source".into());
-    }
-
-    std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
-        name: "create_dir_failed".into(),
-        message: format!(
-            "Failed to create destination directory: {}: {e}",
-            destination_path.to_string_lossy()
-        ),
-    })?;
-    std::fs::rename(&source_path, &destination_path).map_err(|e| UiError {
-        name: "move_failed".into(),
-        message: format!(
-            "Failed to move installations directory: {e}. \
-             Please ensure no other application is using the files."
-        ),
-    })?;
+    move_folder(
+        std::path::PathBuf::from(source).join("installations"),
+        std::path::PathBuf::from(destination).join("installations"),
+    )?;
     Ok("moved".into())
 }
 

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -457,14 +457,9 @@ pub async fn move_installations_folder(
     let destination_path = std::path::PathBuf::from(destination).join("installations");
 
     if !source_path.exists() || !source_path.is_dir() {
-        return Err(UiError {
-            name: "not_found".into(),
-            message: format!(
-                "Source installations directory not found: {}",
-                source_path.to_string_lossy()
-            ),
-        });
+        return Ok("no_source".into());
     }
+
     std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
         name: "create_dir_failed".into(),
         message: format!(

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -447,3 +447,37 @@ pub fn remove_installation(app: AppHandle, id: i64) -> Result<String, UiError> {
         })
     }
 }
+
+#[command]
+pub async fn move_installations_folder(
+    source: String,
+    destination: String,
+) -> Result<String, UiError> {
+    let source_path = std::path::PathBuf::from(source).join("installations");
+    let destination_path = std::path::PathBuf::from(destination).join("installations");
+
+    if !source_path.exists() || !source_path.is_dir() {
+        return Err(UiError {
+            name: "not_found".into(),
+            message: format!(
+                "Source installations directory not found: {}",
+                source_path.to_string_lossy()
+            ),
+        });
+    }
+    std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
+        name: "create_dir_failed".into(),
+        message: format!(
+            "Failed to create destination directory: {}: {e}",
+            destination_path.to_string_lossy()
+        ),
+    })?;
+    std::fs::rename(&source_path, &destination_path).map_err(|e| UiError {
+        name: "move_failed".into(),
+        message: format!(
+            "Failed to move installations directory: {e}. \
+             Please ensure no other application is using the files."
+        ),
+    })?;
+    Ok("moved".into())
+}

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -481,3 +481,22 @@ pub async fn move_installations_folder(
     })?;
     Ok("moved".into())
 }
+
+#[command]
+pub async fn remove_all_installations(source: String) -> Result<String, UiError> {
+    let source_path = std::path::PathBuf::from(source).join("installations");
+    if !source_path.exists() || !source_path.is_dir() {
+        return Err(UiError {
+            name: "not_found".into(),
+            message: format!(
+                "Source installations directory not found: {}",
+                source_path.to_string_lossy()
+            ),
+        });
+    }
+    std::fs::remove_dir_all(&source_path).map_err(|e| UiError {
+        name: "remove_failed".into(),
+        message: format!("Failed to remove installations directory: {e}"),
+    })?;
+    Ok("removed".into())
+}

--- a/src-tauri/src/modules/saves.rs
+++ b/src-tauri/src/modules/saves.rs
@@ -1,10 +1,11 @@
 use serde_json::{from_value, Value};
 use std::{ffi::OsStr, path::Path};
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, AppHandle};
 use tauri_plugin_zustand::ManagerExt;
 
 use super::errors::UiError;
 use super::proto::GameData;
+use super::utils::installations_folder;
 use prost::Message;
 use rusqlite::OpenFlags;
 
@@ -13,7 +14,7 @@ use rusqlite::OpenFlags;
 #[command]
 pub fn get_all_saves(app: AppHandle) -> Result<Vec<(GameData, String, String)>, UiError> {
     // Look through all installation folders and collect save names from the .vcdbs files
-    let installation_dir_path = app.path().app_data_dir().unwrap().join("installations");
+    let installation_dir_path = installations_folder(app.clone()).join("installations");
     let mut saves = Vec::new();
     if installation_dir_path.exists() && installation_dir_path.is_dir() {
         for entry in std::fs::read_dir(installation_dir_path)

--- a/src-tauri/src/modules/servers.rs
+++ b/src-tauri/src/modules/servers.rs
@@ -1,8 +1,9 @@
 use serde_json::Value;
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, AppHandle};
 use tauri_plugin_zustand::ManagerExt;
 
 use super::errors::UiError;
+use super::utils::installations_folder;
 
 fn extract_servers_from_directory(path: std::path::PathBuf) -> Value {
     let mut servers = Value::Array(vec![]);
@@ -24,7 +25,7 @@ fn extract_servers_from_directory(path: std::path::PathBuf) -> Value {
 
 #[command]
 pub async fn fetch_all_servers(app: AppHandle) -> Result<Value, UiError> {
-    let installation_paths = app.path().app_data_dir().unwrap().join("installations");
+    let installation_paths = installations_folder(app.clone()).join("installations");
     let mut all_servers = Vec::new();
     for entry in std::fs::read_dir(installation_paths).unwrap() {
         let entry = entry.unwrap();

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_zustand::ManagerExt;
 
+use super::errors::UiError;
+
 pub fn versions_folder(app: AppHandle) -> PathBuf {
     let version_parent: Option<String> = app
         .zustand()
@@ -28,4 +30,115 @@ pub fn installations_folder(app: AppHandle) -> PathBuf {
         app.path().app_data_dir().unwrap()
     };
     return data_dir;
+}
+
+pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bool, UiError> {
+    if !destination_path.exists() || !destination_path.is_dir() {
+        std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
+            name: "create_dir_failed".into(),
+            message: format!(
+                "Failed to create destination directory: {}: {e}",
+                destination_path.to_string_lossy()
+            ),
+        })?;
+        for entry in std::fs::read_dir(&source_path).map_err(|e| UiError {
+            name: "io_error".into(),
+            message: format!("Failed to read source directory: {e}"),
+        })? {
+            let entry = entry.map_err(|e| UiError {
+                name: "io_error".into(),
+                message: format!("Failed to read directory entry: {e}"),
+            })?;
+            let dest_file_path = destination_path.join(entry.file_name());
+            if entry.path().is_dir() {
+                std::fs::create_dir_all(&dest_file_path).map_err(|e| UiError {
+                    name: "create_dir_failed".into(),
+                    message: format!(
+                        "Failed to create directory: {}: {e}",
+                        dest_file_path.to_string_lossy()
+                    ),
+                })?;
+                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
+                    name: "copy_failed".into(),
+                    message: format!(
+                        "Failed to copy directory: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+                std::fs::remove_dir_all(&entry.path()).map_err(|e| UiError {
+                    name: "remove_failed".into(),
+                    message: format!(
+                        "Failed to remove source directory: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+            } else {
+                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
+                    name: "copy_failed".into(),
+                    message: format!(
+                        "Failed to copy file: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+                std::fs::remove_file(&entry.path()).map_err(|e| UiError {
+                    name: "remove_failed".into(),
+                    message: format!(
+                        "Failed to remove source file: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+            }
+        }
+    } else {
+        // Move the contents of source to destination
+        for entry in std::fs::read_dir(&source_path).map_err(|e| UiError {
+            name: "io_error".into(),
+            message: format!("Failed to read source directory: {e}"),
+        })? {
+            let entry = entry.map_err(|e| UiError {
+                name: "io_error".into(),
+                message: format!("Failed to read directory entry: {e}"),
+            })?;
+            let dest_file_path = destination_path.join(entry.file_name());
+            if entry.path().is_dir() {
+                std::fs::create_dir_all(&dest_file_path).map_err(|e| UiError {
+                    name: "create_dir_failed".into(),
+                    message: format!(
+                        "Failed to create directory: {}: {e}",
+                        dest_file_path.to_string_lossy()
+                    ),
+                })?;
+                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
+                    name: "copy_failed".into(),
+                    message: format!(
+                        "Failed to copy directory: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+                std::fs::remove_dir_all(&entry.path()).map_err(|e| UiError {
+                    name: "remove_failed".into(),
+                    message: format!(
+                        "Failed to remove source directory: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+            } else {
+                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
+                    name: "copy_failed".into(),
+                    message: format!(
+                        "Failed to copy file: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+                std::fs::remove_file(&entry.path()).map_err(|e| UiError {
+                    name: "remove_failed".into(),
+                    message: format!(
+                        "Failed to remove source file: {}: {e}",
+                        entry.path().to_string_lossy()
+                    ),
+                })?;
+            }
+        }
+    }
+    Ok(true)
 }

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -1,3 +1,4 @@
+use fs_extra::dir::{move_dir, CopyOptions};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_zustand::ManagerExt;
@@ -33,112 +34,25 @@ pub fn installations_folder(app: AppHandle) -> PathBuf {
 }
 
 pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bool, UiError> {
-    if !destination_path.exists() || !destination_path.is_dir() {
-        std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
-            name: "create_dir_failed".into(),
+    if !source_path.exists() || !source_path.is_dir() {
+        return Err(UiError {
+            name: "not_found".into(),
             message: format!(
-                "Failed to create destination directory: {}: {e}",
-                destination_path.to_string_lossy()
+                "Source directory not found: {}",
+                source_path.to_string_lossy()
             ),
-        })?;
-        for entry in std::fs::read_dir(&source_path).map_err(|e| UiError {
-            name: "io_error".into(),
-            message: format!("Failed to read source directory: {e}"),
-        })? {
-            let entry = entry.map_err(|e| UiError {
-                name: "io_error".into(),
-                message: format!("Failed to read directory entry: {e}"),
-            })?;
-            let dest_file_path = destination_path.join(entry.file_name());
-            if entry.path().is_dir() {
-                std::fs::create_dir_all(&dest_file_path).map_err(|e| UiError {
-                    name: "create_dir_failed".into(),
-                    message: format!(
-                        "Failed to create directory: {}: {e}",
-                        dest_file_path.to_string_lossy()
-                    ),
-                })?;
-                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
-                    name: "copy_failed".into(),
-                    message: format!(
-                        "Failed to copy directory: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-                std::fs::remove_dir_all(&entry.path()).map_err(|e| UiError {
-                    name: "remove_failed".into(),
-                    message: format!(
-                        "Failed to remove source directory: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-            } else {
-                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
-                    name: "copy_failed".into(),
-                    message: format!(
-                        "Failed to copy file: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-                std::fs::remove_file(&entry.path()).map_err(|e| UiError {
-                    name: "remove_failed".into(),
-                    message: format!(
-                        "Failed to remove source file: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-            }
-        }
-    } else {
-        // Move the contents of source to destination
-        for entry in std::fs::read_dir(&source_path).map_err(|e| UiError {
-            name: "io_error".into(),
-            message: format!("Failed to read source directory: {e}"),
-        })? {
-            let entry = entry.map_err(|e| UiError {
-                name: "io_error".into(),
-                message: format!("Failed to read directory entry: {e}"),
-            })?;
-            let dest_file_path = destination_path.join(entry.file_name());
-            if entry.path().is_dir() {
-                std::fs::create_dir_all(&dest_file_path).map_err(|e| UiError {
-                    name: "create_dir_failed".into(),
-                    message: format!(
-                        "Failed to create directory: {}: {e}",
-                        dest_file_path.to_string_lossy()
-                    ),
-                })?;
-                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
-                    name: "copy_failed".into(),
-                    message: format!(
-                        "Failed to copy directory: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-                std::fs::remove_dir_all(&entry.path()).map_err(|e| UiError {
-                    name: "remove_failed".into(),
-                    message: format!(
-                        "Failed to remove source directory: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-            } else {
-                std::fs::copy(&entry.path(), &dest_file_path).map_err(|e| UiError {
-                    name: "copy_failed".into(),
-                    message: format!(
-                        "Failed to copy file: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-                std::fs::remove_file(&entry.path()).map_err(|e| UiError {
-                    name: "remove_failed".into(),
-                    message: format!(
-                        "Failed to remove source file: {}: {e}",
-                        entry.path().to_string_lossy()
-                    ),
-                })?;
-            }
-        }
+        });
     }
+
+    let mut options = CopyOptions::new();
+    options.overwrite = true;
+    options.copy_inside = true;
+    options.skip_exist = true;
+
+    move_dir(&source_path, &destination_path, &options).map_err(|e| UiError {
+        name: "move_failed".into(),
+        message: format!("Failed to move directory: {e}"),
+    })?;
+
     Ok(true)
 }

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_zustand::ManagerExt;
+
+pub fn versions_folder(app: AppHandle) -> PathBuf {
+    let version_parent: Option<String> = app
+        .zustand()
+        .get::<Option<String>>("settings", "versionsParent")
+        .ok()
+        .flatten();
+    let data_dir = if let Some(vp) = version_parent {
+        PathBuf::from(vp)
+    } else {
+        app.path().app_data_dir().unwrap()
+    };
+    return data_dir;
+}
+
+pub fn installations_folder(app: AppHandle) -> PathBuf {
+    let installations_parent: Option<String> = app
+        .zustand()
+        .get::<Option<String>>("settings", "installationsParent")
+        .ok()
+        .flatten();
+    let data_dir = if let Some(ip) = installations_parent {
+        PathBuf::from(ip)
+    } else {
+        app.path().app_data_dir().unwrap()
+    };
+    return data_dir;
+}

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -1,14 +1,12 @@
-use tauri::{command, AppHandle, Manager};
+use tauri::{command, AppHandle};
 
 use super::errors::UiError;
+use super::utils::versions_folder;
 
 #[command]
 pub fn get_installed_versions(app: AppHandle) -> Result<Vec<String>, UiError> {
     // Should look up the versions folder and return a list of installed versions
-    let base_dir = app
-        .path()
-        .app_data_dir()
-        .expect("Failed to get app local data dir");
+    let base_dir = versions_folder(app.clone());
     let versions_dir = base_dir.join("versions");
     if !versions_dir.exists() || !versions_dir.is_dir() {
         return Ok(vec![]);
@@ -33,12 +31,7 @@ pub fn get_installed_versions(app: AppHandle) -> Result<Vec<String>, UiError> {
 
 #[command]
 pub fn remove_installed_version(version: String, app: AppHandle) -> Result<String, UiError> {
-    let versions_path = app
-        .path()
-        .app_data_dir()
-        .unwrap()
-        .join("versions")
-        .join(&version);
+    let versions_path = versions_folder(app.clone()).join("versions").join(&version);
     if !versions_path.exists() || !versions_path.is_dir() {
         return Err(UiError {
             name: "not_found".into(),

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -101,3 +101,25 @@ pub async fn move_versions_folder(source: String, destination: String) -> Result
 
     Ok("moved".into())
 }
+
+#[command]
+pub async fn remove_all_versions(source: String) -> Result<String, UiError> {
+    let source_path = std::path::PathBuf::from(source).join("versions");
+
+    if !source_path.exists() || !source_path.is_dir() {
+        return Err(UiError {
+            name: "not_found".into(),
+            message: format!(
+                "Source directory not found: {}",
+                source_path.to_string_lossy()
+            ),
+        });
+    }
+
+    std::fs::remove_dir_all(&source_path).map_err(|e| UiError {
+        name: "remove_failed".into(),
+        message: format!("Failed to remove versions directory: {e}"),
+    })?;
+
+    Ok("removed".into())
+}

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -1,5 +1,7 @@
 use tauri::{command, AppHandle};
 
+use crate::modules::utils::move_folder;
+
 use super::errors::UiError;
 use super::utils::versions_folder;
 
@@ -71,28 +73,10 @@ pub async fn fetch_versions() -> Result<Vec<String>, UiError> {
 
 #[command]
 pub async fn move_versions_folder(source: String, destination: String) -> Result<String, UiError> {
-    let source_path = std::path::PathBuf::from(source).join("versions");
-    let destination_path = std::path::PathBuf::from(destination).join("versions");
-
-    if !source_path.exists() || !source_path.is_dir() {
-        return Ok("no_source".into());
-    }
-
-    if destination_path.exists() {
-        return Err(UiError {
-            name: "already_exists".into(),
-            message: format!(
-                "Destination directory already exists: {}",
-                destination_path.to_string_lossy()
-            ),
-        });
-    }
-
-    std::fs::rename(&source_path, &destination_path).map_err(|e| UiError {
-        name: "move_failed".into(),
-        message: format!("Failed to move directory: {e}"),
-    })?;
-
+    move_folder(
+        std::path::PathBuf::from(source).join("versions"),
+        std::path::PathBuf::from(destination).join("versions"),
+    )?;
     Ok("moved".into())
 }
 

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -68,3 +68,36 @@ pub async fn fetch_versions() -> Result<Vec<String>, UiError> {
 
     Ok(json)
 }
+
+#[command]
+pub async fn move_versions_folder(source: String, destination: String) -> Result<String, UiError> {
+    let source_path = std::path::PathBuf::from(source).join("versions");
+    let destination_path = std::path::PathBuf::from(destination).join("versions");
+
+    if !source_path.exists() || !source_path.is_dir() {
+        return Err(UiError {
+            name: "not_found".into(),
+            message: format!(
+                "Source directory not found: {}",
+                source_path.to_string_lossy()
+            ),
+        });
+    }
+
+    if destination_path.exists() {
+        return Err(UiError {
+            name: "already_exists".into(),
+            message: format!(
+                "Destination directory already exists: {}",
+                destination_path.to_string_lossy()
+            ),
+        });
+    }
+
+    std::fs::rename(&source_path, &destination_path).map_err(|e| UiError {
+        name: "move_failed".into(),
+        message: format!("Failed to move directory: {e}"),
+    })?;
+
+    Ok("moved".into())
+}

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -75,13 +75,7 @@ pub async fn move_versions_folder(source: String, destination: String) -> Result
     let destination_path = std::path::PathBuf::from(destination).join("versions");
 
     if !source_path.exists() || !source_path.is_dir() {
-        return Err(UiError {
-            name: "not_found".into(),
-            message: format!(
-                "Source directory not found: {}",
-                source_path.to_string_lossy()
-            ),
-        });
+        return Ok("no_source".into());
     }
 
     if destination_path.exists() {

--- a/src/components/cards/installation.card.tsx
+++ b/src/components/cards/installation.card.tsx
@@ -1,5 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { listen } from "@tauri-apps/api/event";
 import { formatDistanceToNow } from "date-fns";
 import {
 	DownloadCloudIcon,
@@ -8,15 +6,9 @@ import {
 	Play,
 	Star,
 } from "lucide-react";
-import { useRef } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useDownloadVersion } from "@/hooks/use-download-version";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
-import type { ProgressPayload } from "@/lib/types";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { cn } from "@/lib/utils";
 import type { Installation } from "@/stores/installations";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
@@ -36,55 +28,8 @@ export function InstallationCard({
 	onEdit,
 	onAddMods,
 }: InstallationCardProps) {
-	const listenRef = useRef<() => void>(null);
-	const queryClient = useQueryClient();
-
 	const { mutate: installVersion, isPending: isInstalling } =
-		useDownloadVersion({
-			onError: (error, v) => {
-				listenRef.current?.();
-				toast.error(`Error downloading game version: ${error.message}`, {
-					id: `download-game-version-${v}`,
-				});
-			},
-			onMutate: async (v) => {
-				toast.loading(`Starting to download game version ${v}...`, {
-					id: `download-game-version-${v}`,
-				});
-				listenRef.current = await listen<ProgressPayload>(
-					`download://version:${v.replace(/\./g, "_")}`,
-					(event) => {
-						const { phase, percent } = event.payload;
-						if (phase === "download") {
-							toast.loading(
-								`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-								{
-									id: `download-game-version-${v}`,
-								},
-							);
-						}
-						if (phase === "extract") {
-							toast.loading(`Extracting game version ${v}`, {
-								id: `download-game-version-${v}`,
-							});
-						}
-					},
-				);
-			},
-			onSuccess: (d, v) => {
-				listenRef.current?.();
-				if (d === "already_downloaded") {
-					toast.dismiss(`download-game-version-${v}`);
-					return;
-				}
-				toast.success(`Game version ${v} downloaded`, {
-					id: `download-game-version-${v}`,
-				});
-				queryClient.invalidateQueries({
-					queryKey: installedVersionsQueryKey(),
-				});
-			},
-		});
+		useDownloadVersion();
 
 	const { data: versions } = useInstalledVersions();
 	return (

--- a/src/components/cards/server.card.tsx
+++ b/src/components/cards/server.card.tsx
@@ -5,6 +5,7 @@ import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { cn } from "@/lib/utils";
 import { useInstallations } from "@/stores/installations";
 import type { Server } from "@/stores/servers";
+import { useSettingsStore } from "@/stores/settings";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 interface ServerCardProps {
@@ -23,6 +24,7 @@ export function ServerCard({
 	const serverAddress = server.port ? `${server.ip}:${server.port}` : server.ip;
 	const hasPassword = server.password && server.password.length > 0;
 	const { installations } = useInstallations();
+	const { streamMode } = useSettingsStore();
 	const installation = installations.find(
 		(inst) => inst.id === server.installationId,
 	);
@@ -51,7 +53,7 @@ export function ServerCard({
 					</p>
 					{installation.version && (
 						<p className="font-mono text-xs text-muted-foreground">
-							v{installation.version} - {serverAddress}
+							v{installation.version} - {streamMode ? "hidden" : serverAddress}
 						</p>
 					)}
 				</div>

--- a/src/components/cards/server.card.tsx
+++ b/src/components/cards/server.card.tsx
@@ -1,15 +1,7 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { DownloadCloudIcon, Lock, Pencil, Play, Star } from "lucide-react";
-import { useRef } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useDownloadVersion } from "@/hooks/use-download-version";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
-import type { ProgressPayload } from "@/lib/types";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { cn } from "@/lib/utils";
 import { useInstallations } from "@/stores/installations";
 import type { Server } from "@/stores/servers";
@@ -28,8 +20,6 @@ export function ServerCard({
 	onUnfavorite,
 	onEdit,
 }: ServerCardProps) {
-	const queryClient = useQueryClient();
-	const listenRef = useRef<UnlistenFn>(null);
 	const serverAddress = server.port ? `${server.ip}:${server.port}` : server.ip;
 	const hasPassword = server.password && server.password.length > 0;
 	const { installations } = useInstallations();
@@ -39,51 +29,7 @@ export function ServerCard({
 	const { data: versions } = useInstalledVersions();
 
 	const { mutate: installVersion, isPending: isInstalling } =
-		useDownloadVersion({
-			onError: (error, v) => {
-				listenRef.current?.();
-				toast.error(`Error downloading game version: ${error.message}`, {
-					id: `download-game-version-${v}`,
-				});
-			},
-			onMutate: async (v) => {
-				toast.loading(`Starting to download game version ${v}...`, {
-					id: `download-game-version-${v}`,
-				});
-				listenRef.current = await listen<ProgressPayload>(
-					`download://version:${v.replace(/\./g, "_")}`,
-					(event) => {
-						const { phase, percent } = event.payload;
-						if (phase === "download") {
-							toast.loading(
-								`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-								{
-									id: `download-game-version-${v}`,
-								},
-							);
-						}
-						if (phase === "extract") {
-							toast.loading(`Extracting game version ${v}`, {
-								id: `download-game-version-${v}`,
-							});
-						}
-					},
-				);
-			},
-			onSuccess: (d, v) => {
-				listenRef.current?.();
-				if (d === "already_downloaded") {
-					toast.dismiss(`download-game-version-${v}`);
-					return;
-				}
-				toast.success(`Game version ${v} downloaded`, {
-					id: `download-game-version-${v}`,
-				});
-				queryClient.invalidateQueries({
-					queryKey: installedVersionsQueryKey(),
-				});
-			},
-		});
+		useDownloadVersion();
 	if (!installation) return null;
 
 	return (

--- a/src/components/dialogs/addinstallation.dialog.tsx
+++ b/src/components/dialogs/addinstallation.dialog.tsx
@@ -31,7 +31,11 @@ import { useAppFolder } from "@/hooks/use-app-folder";
 import { useDownloadVersion } from "@/hooks/use-download-version";
 import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { gameVersionsQuery } from "@/lib/queries";
-import { compareSemverDesc, makeStringFolderSafe } from "@/lib/utils";
+import {
+	compareSemverDesc,
+	makeStringFolderSafe,
+	pathDelimiter,
+} from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { useInstallationsStore } from "@/stores/installations";
 import { useSettingsStore } from "@/stores/settings";
@@ -87,7 +91,9 @@ export function AddInstallationDialog({ open }: { open: boolean }) {
 			id: Date.now(),
 			index: installations.length,
 			name: "",
-			path: appFolder ? `${appFolder}/installations/new` : "",
+			path: appFolder
+				? `${appFolder}${pathDelimiter}installations${pathDelimiter}new`
+				: "",
 			startParams: "",
 			version:
 				gameVersions
@@ -186,7 +192,7 @@ export function AddInstallationDialog({ open }: { open: boolean }) {
 												const safeName = makeStringFolderSafe(e.target.value);
 												form.setFieldValue(
 													"path",
-													`${installationsParent ?? appFolder}/installations/${safeName}`,
+													`${installationsParent ?? appFolder}${pathDelimiter}installations${pathDelimiter}${safeName}`,
 												);
 											} else {
 												form.resetField("path");

--- a/src/components/dialogs/addinstallation.dialog.tsx
+++ b/src/components/dialogs/addinstallation.dialog.tsx
@@ -1,9 +1,8 @@
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import clsx from "clsx";
-import { useId, useRef } from "react";
+import { useId } from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { Button } from "@/components/ui/button";
@@ -29,16 +28,13 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAppFolder } from "@/hooks/use-app-folder";
+import { useDownloadVersion } from "@/hooks/use-download-version";
 import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { gameVersionsQuery } from "@/lib/queries";
-import type { ProgressPayload } from "@/lib/types";
-import {
-	compareSemverDesc,
-	makeStringFolderSafe,
-	zipfolderprefix,
-} from "@/lib/utils";
+import { compareSemverDesc, makeStringFolderSafe } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { useInstallationsStore } from "@/stores/installations";
+import { useSettingsStore } from "@/stores/settings";
 
 export const installationSchema = z.object({
 	favorite: z.boolean(),
@@ -58,72 +54,12 @@ export const installationSchema = z.object({
 export function AddInstallationDialog({ open }: { open: boolean }) {
 	const id = useId();
 	const { data: gameVersions } = useQuery(gameVersionsQuery);
+	const { installationsParent } = useSettingsStore();
 	const { appFolder } = useAppFolder();
 	const { closeDialog } = useDialogStore();
 	const { addInstallation, installations } = useInstallationsStore();
-	const listenRef = useRef<UnlistenFn>(null);
 	const { data: installedVersions } = useInstalledVersions();
-	const { mutateAsync: downloadVersion, isPending } = useMutation({
-		mutationFn: async (version: string) => {
-			const url = (await invoke("get_download_link", {
-				version,
-			})) as string;
-			if (!url) {
-				throw new Error("Download URL not found in response");
-			}
-			const downloadUrl = url;
-			if (!appFolder) {
-				throw new Error("App folder not found");
-			}
-			return invoke("download_and_maybe_extract", {
-				destpath: `${appFolder}/versions/${version}`,
-				emitevent: `download://version:${version.replace(/\./g, "_")}`,
-				extract: true,
-				extractdir: `${appFolder}/versions/${version}`,
-				url: downloadUrl,
-				zipsubfolderprefix: zipfolderprefix(),
-			}) as Promise<string>;
-		},
-		onError: (error, v) => {
-			toast.error(`Error downloading game version: ${error.message}`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current?.();
-		},
-		onMutate: async (v) => {
-			toast.loading(`Starting to download game version ${v}...`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current = await listen<ProgressPayload>(
-				`download://version:${v.replace(/\./g, "_")}`,
-				(event) => {
-					const { phase, percent } = event.payload;
-					if (phase === "download") {
-						toast.loading(
-							`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-							{
-								id: `download-game-version-${v}`,
-							},
-						);
-					} else if (phase === "extract") {
-						toast.loading(`Extracting game version ${v}...`, {
-							id: `download-game-version-${v}`,
-						});
-					}
-				},
-			);
-		},
-		onSuccess: (d, v) => {
-			if (d === "already_downloaded") {
-				toast.dismiss(`download-game-version-${v}`);
-				return;
-			}
-			toast.success(`Game version ${v} downloaded`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current?.();
-		},
-	});
+	const { mutateAsync: downloadVersion, isPending } = useDownloadVersion();
 	const { mutateAsync: initializeGame, isPending: initializePending } =
 		useMutation({
 			mutationFn: (path: string) =>
@@ -250,7 +186,7 @@ export function AddInstallationDialog({ open }: { open: boolean }) {
 												const safeName = makeStringFolderSafe(e.target.value);
 												form.setFieldValue(
 													"path",
-													`${appFolder}/installations/${safeName}`,
+													`${installationsParent ?? appFolder}/installations/${safeName}`,
 												);
 											} else {
 												form.resetField("path");

--- a/src/components/dialogs/addversion.dialog.tsx
+++ b/src/components/dialogs/addversion.dialog.tsx
@@ -1,10 +1,7 @@
 import { useForm, useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useQuery } from "@tanstack/react-query";
 import { platform } from "@tauri-apps/plugin-os";
 import clsx from "clsx";
-import { useRef } from "react";
-import { toast } from "sonner";
 import z from "zod";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,12 +24,8 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useDownloadVersion } from "@/hooks/use-download-version";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { gameVersionsQuery } from "@/lib/queries";
-import type { ProgressPayload } from "@/lib/types";
 import { compareSemverDesc } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 
@@ -41,10 +34,8 @@ export const versionSchema = z.object({
 });
 
 export function AddVersionDialog({ open }: { open: boolean }) {
-	const queryClient = useQueryClient();
 	const { data: gameVersions } = useQuery(gameVersionsQuery);
 	const { closeDialog } = useDialogStore();
-	const listenRef = useRef<UnlistenFn>(null);
 	const { data: installedVersions } = useInstalledVersions();
 	const currentPlatform = platform();
 
@@ -54,52 +45,7 @@ export function AddVersionDialog({ open }: { open: boolean }) {
 
 	const sortedVersions = gameVersions?.sort(compareSemverDesc);
 
-	const { mutateAsync: downloadVersion, isPending } = useDownloadVersion({
-		onError: (error, v) => {
-			listenRef.current?.();
-			toast.error(`Error downloading game version: ${error.message}`, {
-				id: `download-game-version-${v}`,
-			});
-		},
-		onMutate: async (v) => {
-			toast.loading(`Starting to download game version ${v}...`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current = await listen<ProgressPayload>(
-				`download://version:${v.replace(/\./g, "_")}`,
-				(event) => {
-					const { phase, percent } = event.payload;
-					if (phase === "download") {
-						toast.loading(
-							`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-							{
-								id: `download-game-version-${v}`,
-							},
-						);
-					}
-					if (phase === "extract") {
-						toast.loading(`Extracting game version ${v}`, {
-							id: `download-game-version-${v}`,
-						});
-					}
-				},
-			);
-		},
-		onSuccess: (d, v) => {
-			listenRef.current?.();
-			if (d === "already_downloaded") {
-				toast.dismiss(`download-game-version-${v}`);
-				return;
-			}
-			toast.success(`Game version ${v} downloaded`, {
-				id: `download-game-version-${v}`,
-			});
-			queryClient.invalidateQueries({
-				queryKey: installedVersionsQueryKey(),
-			});
-			closeDialog();
-		},
-	});
+	const { mutateAsync: downloadVersion, isPending } = useDownloadVersion();
 	const form = useForm({
 		defaultValues: {
 			version:

--- a/src/components/dialogs/editinstallation.dialog.tsx
+++ b/src/components/dialogs/editinstallation.dialog.tsx
@@ -28,7 +28,11 @@ import { useAppFolder } from "@/hooks/use-app-folder";
 import { useDownloadVersion } from "@/hooks/use-download-version";
 import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { gameVersionsQuery } from "@/lib/queries";
-import { compareSemverDesc, makeStringFolderSafe } from "@/lib/utils";
+import {
+	compareSemverDesc,
+	makeStringFolderSafe,
+	pathDelimiter,
+} from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import {
 	type Installation,
@@ -154,7 +158,7 @@ export function EditInstallationDialog({
 												const safeName = makeStringFolderSafe(e.target.value);
 												form.setFieldValue(
 													"path",
-													`${installationsParent ?? appFolder}/installations/${safeName}`,
+													`${installationsParent ?? appFolder}${pathDelimiter}installations${pathDelimiter}${safeName}`,
 												);
 											} else {
 												form.resetField("path");

--- a/src/components/dialogs/editinstallation.dialog.tsx
+++ b/src/components/dialogs/editinstallation.dialog.tsx
@@ -1,10 +1,7 @@
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
-import { useId, useRef } from "react";
-import { toast } from "sonner";
+import { useId } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -28,22 +25,16 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAppFolder } from "@/hooks/use-app-folder";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
+import { useDownloadVersion } from "@/hooks/use-download-version";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { gameVersionsQuery } from "@/lib/queries";
-import type { ProgressPayload } from "@/lib/types";
-import {
-	compareSemverDesc,
-	makeStringFolderSafe,
-	zipfolderprefix,
-} from "@/lib/utils";
+import { compareSemverDesc, makeStringFolderSafe } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import {
 	type Installation,
 	useInstallationsStore,
 } from "@/stores/installations";
+import { useSettingsStore } from "@/stores/settings";
 import { installationSchema } from "./addinstallation.dialog";
 
 export type EditInstallationDialogProps = {
@@ -61,73 +52,9 @@ export function EditInstallationDialog({
 	const { closeDialog } = useDialogStore();
 	const { data: installedVersions } = useInstalledVersions();
 	const { appFolder } = useAppFolder();
-	const queryClient = useQueryClient();
-	const listenRef = useRef<UnlistenFn>(null);
+	const { installationsParent } = useSettingsStore();
 	const { updateInstallation } = useInstallationsStore();
-	const { mutateAsync: downloadVersion, isPending } = useMutation({
-		mutationFn: async (version: string) => {
-			const url = (await invoke("get_download_link", {
-				version,
-			})) as string;
-			if (!url) {
-				throw new Error("Download URL not found in response");
-			}
-			const downloadUrl = url;
-			if (!appFolder) {
-				throw new Error("App folder not found");
-			}
-			return invoke("download_and_maybe_extract", {
-				destpath: `${appFolder}/versions/${version}`,
-				emitevent: `download://version:${version.replace(/\./g, "_")}`,
-				extract: true,
-				extractdir: `${appFolder}/versions/${version}`,
-				url: downloadUrl,
-				zipsubfolderprefix: zipfolderprefix(),
-			}) as Promise<string>;
-		},
-		onError: (error, v) => {
-			toast.error(`Error downloading game version: ${error.message}`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current?.();
-		},
-		onMutate: async (v) => {
-			toast.loading(`Starting to download game version ${v}...`, {
-				id: `download-game-version-${v}`,
-			});
-			listenRef.current = await listen<ProgressPayload>(
-				`download://version:${v.replace(/\./g, "_")}`,
-				(event) => {
-					const { phase, percent } = event.payload;
-					if (phase === "download") {
-						toast.loading(
-							`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-							{
-								id: `download-game-version-${v}`,
-							},
-						);
-					} else if (phase === "extract") {
-						toast.loading(`Extracting game version ${v}...`, {
-							id: `download-game-version-${v}`,
-						});
-					}
-				},
-			);
-		},
-		onSuccess: async (d, v) => {
-			listenRef.current?.();
-			if (d === "already_downloaded") {
-				toast.dismiss(`download-game-version-${v}`);
-				return;
-			}
-			await queryClient.invalidateQueries({
-				queryKey: installedVersionsQueryKey(),
-			});
-			toast.success(`Game version ${v} downloaded`, {
-				id: `download-game-version-${v}`,
-			});
-		},
-	});
+	const { mutateAsync: downloadVersion, isPending } = useDownloadVersion();
 	const form = useForm({
 		defaultValues: {
 			favorite: installation.favorite,
@@ -227,7 +154,7 @@ export function EditInstallationDialog({
 												const safeName = makeStringFolderSafe(e.target.value);
 												form.setFieldValue(
 													"path",
-													`${appFolder}/installations/${safeName}`,
+													`${installationsParent ?? appFolder}/installations/${safeName}`,
 												);
 											} else {
 												form.resetField("path");

--- a/src/components/dialogs/importinstallation.dialog.tsx
+++ b/src/components/dialogs/importinstallation.dialog.tsx
@@ -18,7 +18,7 @@ import { useAppFolder } from "@/hooks/use-app-folder";
 import { installedModsQueryKey } from "@/hooks/use-installed-mods";
 import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import type { ModInfo, ProgressPayload } from "@/lib/types";
-import { makeStringFolderSafe } from "@/lib/utils";
+import { makeStringFolderSafe, pathDelimiter } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { useInstallations } from "@/stores/installations";
 import { useSettingsStore } from "@/stores/settings";
@@ -157,7 +157,7 @@ export function ImportInstallationDialog({ open }: { open: boolean }) {
 		);
 		if (installation.success) {
 			await initializeGame(
-				`${installationsParent ?? appFolder}/installations/${makeStringFolderSafe(installation.data.name)}`,
+				`${installationsParent ?? appFolder}${pathDelimiter}installations${pathDelimiter}${makeStringFolderSafe(installation.data.name)}`,
 			);
 		}
 	};

--- a/src/components/dialogs/importinstallation.dialog.tsx
+++ b/src/components/dialogs/importinstallation.dialog.tsx
@@ -21,6 +21,7 @@ import type { ModInfo, ProgressPayload } from "@/lib/types";
 import { makeStringFolderSafe } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { useInstallations } from "@/stores/installations";
+import { useSettingsStore } from "@/stores/settings";
 import { Button } from "../ui/button";
 
 const installationSchema = z.object({
@@ -40,6 +41,7 @@ export function ImportInstallationDialog({ open }: { open: boolean }) {
 	const { closeDialog } = useDialogStore();
 	const listenRef = useRef<() => void>(null);
 	const queryClient = useQueryClient();
+	const { installationsParent } = useSettingsStore();
 	const { appFolder } = useAppFolder();
 
 	const { mutate: addModToInstallation, isPending } = useAddModToInstallation({
@@ -155,7 +157,7 @@ export function ImportInstallationDialog({ open }: { open: boolean }) {
 		);
 		if (installation.success) {
 			await initializeGame(
-				`${appFolder}/installations/${makeStringFolderSafe(installation.data.name)}`,
+				`${installationsParent ?? appFolder}/installations/${makeStringFolderSafe(installation.data.name)}`,
 			);
 		}
 	};

--- a/src/components/items/world.item.tsx
+++ b/src/components/items/world.item.tsx
@@ -1,6 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { formatDistanceToNow } from "date-fns";
 import {
 	DownloadCloudIcon,
@@ -10,7 +8,6 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { motion } from "motion/react";
-import { useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,12 +17,8 @@ import {
 } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useDownloadVersion } from "@/hooks/use-download-version";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import type { GameData } from "@/hooks/use-saves";
-import type { ProgressPayload } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { useInstallations } from "@/stores/installations";
@@ -61,54 +54,8 @@ export const WorldItem = ({
 		(installation) => installation.path.split("/").pop() === world[2],
 	);
 	const version = versions?.find((v) => v === installation?.version);
-	const listenRef = useRef<() => void>(null);
-	const queryClient = useQueryClient();
 	const { mutate: installVersion, isPending: isInstalling } =
-		useDownloadVersion({
-			onError: (error, v) => {
-				listenRef.current?.();
-				toast.error(`Error downloading game version: ${error.message}`, {
-					id: `download-game-version-${v}`,
-				});
-			},
-			onMutate: async (v) => {
-				toast.loading(`Starting to download game version ${v}...`, {
-					id: `download-game-version-${v}`,
-				});
-				listenRef.current = await listen<ProgressPayload>(
-					`download://version:${v.replace(/\./g, "_")}`,
-					(event) => {
-						const { phase, percent } = event.payload;
-						if (phase === "download") {
-							toast.loading(
-								`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-								{
-									id: `download-game-version-${v}`,
-								},
-							);
-						}
-						if (phase === "extract") {
-							toast.loading(`Extracting game version ${v}`, {
-								id: `download-game-version-${v}`,
-							});
-						}
-					},
-				);
-			},
-			onSuccess: (d, v) => {
-				listenRef.current?.();
-				if (d === "already_downloaded") {
-					toast.dismiss(`download-game-version-${v}`);
-					return;
-				}
-				toast.success(`Game version ${v} downloaded`, {
-					id: `download-game-version-${v}`,
-				});
-				queryClient.invalidateQueries({
-					queryKey: installedVersionsQueryKey(),
-				});
-			},
-		});
+		useDownloadVersion();
 	if (!installation) return null;
 	if (!worldData) return null;
 	return (

--- a/src/components/rows/installation.row.tsx
+++ b/src/components/rows/installation.row.tsx
@@ -2,9 +2,7 @@ import type {
 	DraggableAttributes,
 	DraggableSyntheticListeners,
 } from "@dnd-kit/core";
-import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { listen } from "@tauri-apps/api/event";
 import { formatDistanceToNow } from "date-fns";
 import {
 	DownloadCloudIcon,
@@ -17,7 +15,6 @@ import {
 	StarIcon,
 	XIcon,
 } from "lucide-react";
-import { useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,11 +24,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useDownloadVersion } from "@/hooks/use-download-version";
 import { useInstalledMods } from "@/hooks/use-installed-mods";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
-import type { ProgressPayload } from "@/lib/types";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { cn } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import type { Installation } from "@/stores/installations";
@@ -60,55 +53,9 @@ export function InstallationRow({
 	style,
 }: InstallationRowProps) {
 	const router = useRouter();
-	const listenRef = useRef<() => void>(null);
 	const { data: versions } = useInstalledVersions();
-	const queryClient = useQueryClient();
 	const { mutate: installVersion, isPending: isInstalling } =
-		useDownloadVersion({
-			onError: (error, v) => {
-				listenRef.current?.();
-				toast.error(`Error downloading game version: ${error.message}`, {
-					id: `download-game-version-${v}`,
-				});
-			},
-			onMutate: async (v) => {
-				toast.loading(`Starting to download game version ${v}...`, {
-					id: `download-game-version-${v}`,
-				});
-				listenRef.current = await listen<ProgressPayload>(
-					`download://version:${v.replace(/\./g, "_")}`,
-					(event) => {
-						const { phase, percent } = event.payload;
-						if (phase === "download") {
-							toast.loading(
-								`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-								{
-									id: `download-game-version-${v}`,
-								},
-							);
-						}
-						if (phase === "extract") {
-							toast.loading(`Extracting game version ${v}`, {
-								id: `download-game-version-${v}`,
-							});
-						}
-					},
-				);
-			},
-			onSuccess: (d, v) => {
-				listenRef.current?.();
-				if (d === "already_downloaded") {
-					toast.dismiss(`download-game-version-${v}`);
-					return;
-				}
-				toast.success(`Game version ${v} downloaded`, {
-					id: `download-game-version-${v}`,
-				});
-				queryClient.invalidateQueries({
-					queryKey: installedVersionsQueryKey(),
-				});
-			},
-		});
+		useDownloadVersion();
 	const { data: installationMods } = useInstalledMods(installation.path);
 	const version = versions?.find((v) => v === installation.version);
 	const { openDialog } = useDialogStore();

--- a/src/components/sidebars/app.sidebar.tsx
+++ b/src/components/sidebars/app.sidebar.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import {
 	CheckIcon,
 	CircleFadingPlusIcon,
+	CogIcon,
 	EarthIcon,
 	FolderIcon,
 	GlobeIcon,
@@ -319,6 +320,21 @@ export function AppSidebar() {
 				</SidebarGroup>
 			</SidebarContent>
 			<SidebarFooter>
+				<Link to="/settings" viewTransition={{ types: ["warp"] }}>
+					<button
+						className="group/button relative w-auto cursor-pointer overflow-hidden rounded-md border bg-background p-2 px-6 text-center font-semibold w-full"
+						type="button"
+					>
+						<div className="flex items-center justify-center gap-2">
+							<div className="h-2 w-2 rounded-full bg-primary transition-all duration-300 absolute opacity-0 group-hover/button:opacity-100 group-hover/button:scale-[100.8]"></div>
+							<CogIcon className="w-4 h-4 inline-block transition-all duration-300 group-hover/button:translate-x-12 group-hover/button:opacity-0" />
+						</div>
+						<div className="absolute top-0 z-10 flex h-full w-full translate-x-12 items-center justify-center gap-2 text-primary-foreground opacity-0 transition-all duration-300 group-hover/button:-translate-x-5 group-hover/button:opacity-100">
+							<span>Settings</span>
+							<CogIcon className="w-4 h-4 inline-block" />
+						</div>
+					</button>
+				</Link>
 				<a
 					className="w-full"
 					href="https://discord.gg/gByx63peUC"

--- a/src/hooks/use-download-version.ts
+++ b/src/hooks/use-download-version.ts
@@ -1,12 +1,25 @@
-import { type UseMutationOptions, useMutation } from "@tanstack/react-query";
+import {
+	type UseMutationOptions,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useRef } from "react";
+import { toast } from "sonner";
+import type { ProgressPayload } from "@/lib/types";
 import { zipfolderprefix } from "@/lib/utils";
+import { useSettingsStore } from "@/stores/settings";
 import { useAppFolder } from "./use-app-folder";
+import { installedVersionsQueryKey } from "./use-installed-versions";
 
 export const useDownloadVersion = (
 	props?: UseMutationOptions<string, Error, string>,
 ) => {
 	const { appFolder } = useAppFolder();
+	const { versionsParent } = useSettingsStore();
+	const queryClient = useQueryClient();
+	const listenRef = useRef<UnlistenFn>(null);
 	return useMutation({
 		mutationFn: async (version: string) => {
 			const url = (await invoke("get_download_link", {
@@ -20,15 +33,57 @@ export const useDownloadVersion = (
 				throw new Error("App folder not found");
 			}
 			return invoke("download_and_maybe_extract", {
-				destpath: `${appFolder}/versions/${version}`,
+				destpath: `${versionsParent ?? appFolder}/versions/${version}`,
 				emitevent: `download://version:${version.replace(/\./g, "_")}`,
 				extract: true,
-				extractdir: `${appFolder}/versions/${version}`,
+				extractdir: `${versionsParent ?? appFolder}/versions/${version}`,
 				url: downloadUrl,
 				zipsubfolderprefix: zipfolderprefix(),
 			}) as Promise<string>;
 		},
 		mutationKey: ["download-version"],
+		onError: (error, v) => {
+			toast.error(`Error downloading game version: ${error.message}`, {
+				id: `download-game-version-${v}`,
+			});
+			listenRef.current?.();
+		},
+		onMutate: async (v) => {
+			toast.loading(`Starting to download game version ${v}...`, {
+				id: `download-game-version-${v}`,
+			});
+			listenRef.current = await listen<ProgressPayload>(
+				`download://version:${v.replace(/\./g, "_")}`,
+				(event) => {
+					const { phase, percent } = event.payload;
+					if (phase === "download") {
+						toast.loading(
+							`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
+							{
+								id: `download-game-version-${v}`,
+							},
+						);
+					} else if (phase === "extract") {
+						toast.loading(`Extracting game version ${v}...`, {
+							id: `download-game-version-${v}`,
+						});
+					}
+				},
+			);
+		},
+		onSuccess: async (d, v) => {
+			listenRef.current?.();
+			if (d === "already_downloaded") {
+				toast.dismiss(`download-game-version-${v}`);
+				return;
+			}
+			await queryClient.invalidateQueries({
+				queryKey: installedVersionsQueryKey(),
+			});
+			toast.success(`Game version ${v} downloaded`, {
+				id: `download-game-version-${v}`,
+			});
+		},
 		scope: {
 			id: "download-version",
 		},

--- a/src/hooks/use-download-version.ts
+++ b/src/hooks/use-download-version.ts
@@ -8,7 +8,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useRef } from "react";
 import { toast } from "sonner";
 import type { ProgressPayload } from "@/lib/types";
-import { zipfolderprefix } from "@/lib/utils";
+import { pathDelimiter, zipfolderprefix } from "@/lib/utils";
 import { useSettingsStore } from "@/stores/settings";
 import { useAppFolder } from "./use-app-folder";
 import { installedVersionsQueryKey } from "./use-installed-versions";
@@ -33,10 +33,10 @@ export const useDownloadVersion = (
 				throw new Error("App folder not found");
 			}
 			return invoke("download_and_maybe_extract", {
-				destpath: `${versionsParent ?? appFolder}/versions/${version}`,
+				destpath: `${versionsParent ?? appFolder}${pathDelimiter}versions${pathDelimiter}${version}`,
 				emitevent: `download://version:${version.replace(/\./g, "_")}`,
 				extract: true,
-				extractdir: `${versionsParent ?? appFolder}/versions/${version}`,
+				extractdir: `${versionsParent ?? appFolder}${pathDelimiter}versions${pathDelimiter}${version}`,
 				url: downloadUrl,
 				zipsubfolderprefix: zipfolderprefix(),
 			}) as Promise<string>;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -46,8 +46,10 @@ export const zipfolderprefix = () => {
 	return "";
 };
 
-export const isMac =
-	navigator.platform.includes("Mac") ||
-	/Macintosh|MacIntel|MacPPC|Mac68K/.test(navigator.userAgent);
+export const isMac = platform() === "macos";
 
 export const modifierLabel = isMac ? "⌘" : "Ctrl+";
+
+export const isWindows = platform() === "windows";
+
+export const pathDelimiter = isWindows ? "\\" : "/";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { routeTree } from "./routeTree.gen";
 import { tauriAccountsHandler } from "./stores/accounts";
 import { tauriInstallationsHandler } from "./stores/installations";
 import { tauriServersHandler } from "./stores/servers";
+import { tauriSettingsHandler } from "./stores/settings";
 
 const theme = await getCurrentWindow().theme();
 if (theme === "dark") {
@@ -16,6 +17,7 @@ if (theme === "dark") {
 	document.body.classList.remove("dark");
 }
 
+await tauriSettingsHandler.start();
 await tauriServersHandler.start();
 await tauriAccountsHandler.start();
 await tauriInstallationsHandler.start();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import { Toaster } from "sonner";
 import { SidebarProvider } from "./components/ui/sidebar";
@@ -10,14 +9,14 @@ import { tauriInstallationsHandler } from "./stores/installations";
 import { tauriServersHandler } from "./stores/servers";
 import { tauriSettingsHandler } from "./stores/settings";
 
-const theme = await getCurrentWindow().theme();
-if (theme === "dark") {
+await tauriSettingsHandler.start();
+const dark = tauriSettingsHandler.store.getState().darkMode;
+if (dark) {
 	document.body.classList.add("dark");
 } else {
 	document.body.classList.remove("dark");
 }
 
-await tauriSettingsHandler.start();
 await tauriServersHandler.start();
 await tauriAccountsHandler.start();
 await tauriInstallationsHandler.start();

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorldsRouteImport } from './routes/worlds'
 import { Route as VersionsRouteImport } from './routes/versions'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ServersRouteImport } from './routes/servers'
 import { Route as PublicServersRouteImport } from './routes/public-servers'
 import { Route as NewsRouteImport } from './routes/news'
@@ -27,6 +28,11 @@ const WorldsRoute = WorldsRouteImport.update({
 const VersionsRoute = VersionsRouteImport.update({
   id: '/versions',
   path: '/versions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ServersRoute = ServersRouteImport.update({
@@ -71,6 +77,7 @@ export interface FileRoutesByFullPath {
   '/news': typeof NewsRoute
   '/public-servers': typeof PublicServersRoute
   '/servers': typeof ServersRoute
+  '/settings': typeof SettingsRoute
   '/versions': typeof VersionsRoute
   '/worlds': typeof WorldsRoute
   '/install-mods/$id': typeof InstallModsIdRoute
@@ -82,6 +89,7 @@ export interface FileRoutesByTo {
   '/news': typeof NewsRoute
   '/public-servers': typeof PublicServersRoute
   '/servers': typeof ServersRoute
+  '/settings': typeof SettingsRoute
   '/versions': typeof VersionsRoute
   '/worlds': typeof WorldsRoute
   '/install-mods/$id': typeof InstallModsIdRoute
@@ -94,6 +102,7 @@ export interface FileRoutesById {
   '/news': typeof NewsRoute
   '/public-servers': typeof PublicServersRoute
   '/servers': typeof ServersRoute
+  '/settings': typeof SettingsRoute
   '/versions': typeof VersionsRoute
   '/worlds': typeof WorldsRoute
   '/install-mods/$id': typeof InstallModsIdRoute
@@ -107,6 +116,7 @@ export interface FileRouteTypes {
     | '/news'
     | '/public-servers'
     | '/servers'
+    | '/settings'
     | '/versions'
     | '/worlds'
     | '/install-mods/$id'
@@ -118,6 +128,7 @@ export interface FileRouteTypes {
     | '/news'
     | '/public-servers'
     | '/servers'
+    | '/settings'
     | '/versions'
     | '/worlds'
     | '/install-mods/$id'
@@ -129,6 +140,7 @@ export interface FileRouteTypes {
     | '/news'
     | '/public-servers'
     | '/servers'
+    | '/settings'
     | '/versions'
     | '/worlds'
     | '/install-mods/$id'
@@ -141,6 +153,7 @@ export interface RootRouteChildren {
   NewsRoute: typeof NewsRoute
   PublicServersRoute: typeof PublicServersRoute
   ServersRoute: typeof ServersRoute
+  SettingsRoute: typeof SettingsRoute
   VersionsRoute: typeof VersionsRoute
   WorldsRoute: typeof WorldsRoute
   InstallModsIdRoute: typeof InstallModsIdRoute
@@ -161,6 +174,13 @@ declare module '@tanstack/react-router' {
       path: '/versions'
       fullPath: '/versions'
       preLoaderRoute: typeof VersionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/servers': {
@@ -221,6 +241,7 @@ const rootRouteChildren: RootRouteChildren = {
   NewsRoute: NewsRoute,
   PublicServersRoute: PublicServersRoute,
   ServersRoute: ServersRoute,
+  SettingsRoute: SettingsRoute,
   VersionsRoute: VersionsRoute,
   WorldsRoute: WorldsRoute,
   InstallModsIdRoute: InstallModsIdRoute,

--- a/src/routes/servers.tsx
+++ b/src/routes/servers.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { type Installation, useInstallations } from "@/stores/installations";
 import { type Server, useServerStore } from "@/stores/servers";
+import { useSettingsStore } from "@/stores/settings";
 
 export const Route = createFileRoute("/servers")({
 	component: RouteComponent,
@@ -98,6 +99,7 @@ function ServerRow({
 	style,
 }: ServerRowProps) {
 	const { openDialog } = useDialogStore();
+	const { streamMode } = useSettingsStore();
 	const { data: versions } = useInstalledVersions();
 
 	const { mutate: installVersion, isPending: isInstalling } =
@@ -125,10 +127,14 @@ function ServerRow({
 			<div className="flex flex-col flex-1">
 				<p className="text-sm">{server.name}</p>
 				<p className="text-xs text-muted-foreground">
-					<span className="text-warning-foreground">
-						{server.ip}
-						{server.port ? `:${server.port}` : ""}
-					</span>
+					{streamMode ? (
+						<span className="text-warning-foreground">hidden</span>
+					) : (
+						<span className="text-warning-foreground">
+							{server.ip}
+							{server.port ? `:${server.port}` : ""}
+						</span>
+					)}
 					<span className="text-muted-foreground">
 						{" "}
 						via {installation?.name ?? "Unknown Installation"}

--- a/src/routes/servers.tsx
+++ b/src/routes/servers.tsx
@@ -18,9 +18,7 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { listen } from "@tauri-apps/api/event";
 import clsx from "clsx";
 import {
 	DownloadCloudIcon,
@@ -31,8 +29,6 @@ import {
 	XIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useRef } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ErrorComponent } from "@/components/ui/error";
 import {
@@ -42,11 +38,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useConnectToServer } from "@/hooks/use-connect-to-server";
 import { useDownloadVersion } from "@/hooks/use-download-version";
-import {
-	installedVersionsQueryKey,
-	useInstalledVersions,
-} from "@/hooks/use-installed-versions";
-import type { ProgressPayload } from "@/lib/types";
+import { useInstalledVersions } from "@/hooks/use-installed-versions";
 import { cn } from "@/lib/utils";
 import { useDialogStore } from "@/stores/dialogs";
 import { type Installation, useInstallations } from "@/stores/installations";
@@ -107,55 +99,9 @@ function ServerRow({
 }: ServerRowProps) {
 	const { openDialog } = useDialogStore();
 	const { data: versions } = useInstalledVersions();
-	const listenRef = useRef<() => void>(null);
-	const queryClient = useQueryClient();
 
 	const { mutate: installVersion, isPending: isInstalling } =
-		useDownloadVersion({
-			onError: (error, v) => {
-				listenRef.current?.();
-				toast.error(`Error downloading game version: ${error.message}`, {
-					id: `download-game-version-${v}`,
-				});
-			},
-			onMutate: async (v) => {
-				toast.loading(`Starting to download game version ${v}...`, {
-					id: `download-game-version-${v}`,
-				});
-				listenRef.current = await listen<ProgressPayload>(
-					`download://version:${v.replace(/\./g, "_")}`,
-					(event) => {
-						const { phase, percent } = event.payload;
-						if (phase === "download") {
-							toast.loading(
-								`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
-								{
-									id: `download-game-version-${v}`,
-								},
-							);
-						}
-						if (phase === "extract") {
-							toast.loading(`Extracting game version ${v}`, {
-								id: `download-game-version-${v}`,
-							});
-						}
-					},
-				);
-			},
-			onSuccess: (d, v) => {
-				listenRef.current?.();
-				if (d === "already_downloaded") {
-					toast.dismiss(`download-game-version-${v}`);
-					return;
-				}
-				toast.success(`Game version ${v} downloaded`, {
-					id: `download-game-version-${v}`,
-				});
-				queryClient.invalidateQueries({
-					queryKey: installedVersionsQueryKey(),
-				});
-			},
-		});
+		useDownloadVersion();
 	return (
 		<div
 			className={clsx([

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,0 +1,457 @@
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useState } from "react";
+import { toast } from "sonner";
+import z from "zod";
+import {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAppFolder } from "@/hooks/use-app-folder";
+import { installedVersionsQueryKey } from "@/hooks/use-installed-versions";
+import { cn } from "@/lib/utils";
+import { type SetParentConfigProps, useSettingsStore } from "@/stores/settings";
+
+export const Route = createFileRoute("/settings")({
+	component: RouteComponent,
+});
+
+const settingsSchema = z.object({
+	darkMode: z.boolean(),
+	installationsParent: z.string().nullable(),
+	streamMode: z.boolean(),
+	versionsParent: z.string().nullable(),
+});
+
+function RouteComponent() {
+	const settingsStore = useSettingsStore();
+	const { appFolder } = useAppFolder();
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [pendingField, setPendingField] = useState<
+		"installationsParent" | "versionsParent" | "both" | null
+	>(null);
+	const [pendingPath, setPendingPath] = useState<string | null>(null);
+	const [configs, setConfigs] = useState<{
+		installationsParent: {
+			moveCurrentData: boolean;
+			deleteCurrentData: boolean;
+		};
+		versionsParent: { moveCurrentData: boolean; deleteCurrentData: boolean };
+	} | null>(null);
+	const queryClient = useQueryClient();
+
+	const [useAppDirectory, setUseAppDirectory] = useState(
+		settingsStore.installationsParent === null &&
+			settingsStore.versionsParent === null,
+	);
+
+	const { mutateAsync: setInstallationsParent } = useMutation({
+		mutationFn: ({
+			path,
+			config,
+		}: {
+			path: string | null;
+			config?: SetParentConfigProps;
+		}) => settingsStore.setInstallationsParent(path, config),
+		onError: (error, v) => {
+			if (settingsStore.installationsParent !== v.path) {
+				toast.error(`Failed to move installations folder: ${error.message}`, {
+					id: "move-installations-folder",
+				});
+			}
+		},
+		onMutate: (v) => {
+			if (settingsStore.installationsParent !== v.path) {
+				toast.loading("Moving installations folder...", {
+					id: "move-installations-folder",
+				});
+			}
+		},
+		onSuccess: (_, v) => {
+			if (settingsStore.installationsParent !== v.path) {
+				toast.success("Installations folder moved", {
+					id: "move-installations-folder",
+				});
+			}
+		},
+	});
+
+	const { mutateAsync: setVersionsParent } = useMutation({
+		mutationFn: ({
+			path,
+			config,
+		}: {
+			path: string | null;
+			config?: SetParentConfigProps;
+		}) => settingsStore.setVersionsParent(path, config),
+		onError: (error, v) => {
+			if (settingsStore.versionsParent !== v.path) {
+				toast.error(`Failed to move versions folder: ${error.message}`, {
+					id: "move-versions-folder",
+				});
+			}
+		},
+		onMutate: (v) => {
+			if (settingsStore.versionsParent !== v.path) {
+				toast.loading("Moving versions folder...", {
+					id: "move-versions-folder",
+				});
+			}
+		},
+		onSuccess: (_, v) => {
+			if (settingsStore.versionsParent !== v.path) {
+				toast.success("Versions folder moved", {
+					id: "move-versions-folder",
+				});
+			}
+		},
+	});
+
+	const form = useForm({
+		defaultValues: {
+			darkMode: settingsStore.darkMode,
+			installationsParent: settingsStore.installationsParent,
+			streamMode: settingsStore.streamMode,
+			versionsParent: settingsStore.versionsParent,
+		},
+		onSubmit: async ({ value }) => {
+			if (
+				!value.installationsParent ||
+				value.installationsParent.trim() === "" ||
+				value.installationsParent.trim() === appFolder
+			) {
+				await setInstallationsParent({
+					config: configs?.installationsParent,
+					path: null,
+				});
+			} else if (
+				value.installationsParent !== settingsStore.installationsParent
+			) {
+				await setInstallationsParent({
+					config: configs?.installationsParent,
+					path: value.installationsParent.trim(),
+				});
+			}
+			if (
+				!value.versionsParent ||
+				value.versionsParent.trim() === "" ||
+				value.versionsParent.trim() === appFolder
+			) {
+				await setVersionsParent({
+					config: configs?.versionsParent,
+					path: null,
+				});
+			} else if (value.versionsParent !== settingsStore.versionsParent) {
+				await setVersionsParent({
+					config: configs?.versionsParent,
+					path: value.versionsParent.trim(),
+				});
+			}
+			if (value.streamMode !== settingsStore.streamMode) {
+				settingsStore.toggleStreamMode();
+			}
+			if (value.darkMode !== settingsStore.darkMode) {
+				settingsStore.toggleDarkMode();
+			}
+			await queryClient.invalidateQueries({ queryKey: ["saves"] });
+			await queryClient.invalidateQueries({
+				queryKey: installedVersionsQueryKey(),
+			});
+			toast.success("Settings saved");
+		},
+		validators: {
+			onChange: settingsSchema,
+		},
+	});
+
+	const handleBrowse = async (
+		fieldName: "installationsParent" | "versionsParent" | "both",
+	) => {
+		const selected = await open({
+			directory: true,
+			multiple: false,
+			title: `Select ${fieldName === "installationsParent" ? "Installations" : fieldName === "versionsParent" ? "Versions" : "All"} Parent Directory`,
+		});
+		if (typeof selected === "string") {
+			setPendingField(fieldName);
+			setPendingPath(selected);
+			setDialogOpen(true);
+		}
+	};
+
+	const handleDialogChoice = async (choice: "keep" | "delete" | "move") => {
+		if (!pendingField) return;
+		const config =
+			choice === "move"
+				? { deleteCurrentData: false, moveCurrentData: true }
+				: choice === "delete"
+					? { deleteCurrentData: true, moveCurrentData: false }
+					: { deleteCurrentData: false, moveCurrentData: false };
+		if (pendingField === "installationsParent") {
+			setConfigs({
+				installationsParent: config,
+				versionsParent: { deleteCurrentData: false, moveCurrentData: false },
+			});
+			form.setFieldValue("installationsParent", pendingPath ?? "");
+		} else if (pendingField === "versionsParent") {
+			setConfigs({
+				installationsParent: {
+					deleteCurrentData: false,
+					moveCurrentData: false,
+				},
+				versionsParent: config,
+			});
+			form.setFieldValue("versionsParent", pendingPath ?? "");
+		} else {
+			setConfigs({
+				installationsParent: config,
+				versionsParent: config,
+			});
+			form.setFieldValue("installationsParent", pendingPath ?? "");
+			form.setFieldValue("versionsParent", pendingPath ?? "");
+		}
+		setDialogOpen(false);
+		setPendingField(null);
+		setPendingPath(null);
+	};
+
+	return (
+		<div className="h-screen w-full grid grid-rows-[min-content] overflow-hidden bg-background">
+			<main className="px-6 py-6 space-y-8 h-full overflow-y-auto">
+				<div className="flex items-center gap-3 mb-4">
+					<Checkbox
+						checked={useAppDirectory}
+						id="useAppDirectory"
+						onCheckedChange={(checked) => {
+							const useAppDir = checked === true;
+							setUseAppDirectory(useAppDir);
+							if (
+								useAppDir &&
+								(settingsStore.installationsParent !== null ||
+									settingsStore.versionsParent !== null)
+							) {
+								setPendingField("both");
+								setPendingPath(appFolder);
+								setDialogOpen(true);
+							}
+						}}
+					/>
+					<Label htmlFor="useAppDirectory">
+						Use App Data Directory for Installations and Versions
+					</Label>
+				</div>
+				<form.Field name="installationsParent">
+					{(field) => (
+						<div className="grid gap-2">
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Label
+										className={cn([
+											field.state.meta.errors.length
+												? "text-destructive"
+												: useAppDirectory
+													? "text-muted-foreground"
+													: "",
+											"w-fit",
+										])}
+										htmlFor="installationsParent"
+									>
+										Installations Parent Directory
+									</Label>
+								</TooltipTrigger>
+								<TooltipContent align="start" side="bottom">
+									<p className="text-xs">Defaults to the app data directory</p>
+									{field.state.meta.errors.length > 0 &&
+										field.state.meta.errors.map((error, index) => (
+											<p
+												className="text-destructive text-xs"
+												// biome-ignore lint/suspicious/noArrayIndexKey: Needed
+												key={index}
+											>
+												{error?.message}
+											</p>
+										))}
+								</TooltipContent>
+							</Tooltip>
+							<div className="flex gap-2">
+								<Input
+									className={
+										field.state.meta.errors.length ? "text-destructive" : ""
+									}
+									disabled={useAppDirectory || form.state.isSubmitting}
+									readOnly
+									value={
+										useAppDirectory ? `${appFolder}` : (field.state.value ?? "")
+									}
+								/>
+								<Button
+									disabled={form.state.isSubmitting || useAppDirectory}
+									onClick={() => handleBrowse("installationsParent")}
+									variant="outline"
+								>
+									Browse
+								</Button>
+							</div>
+						</div>
+					)}
+				</form.Field>
+				<form.Field name="versionsParent">
+					{(field) => (
+						<div className="grid gap-2">
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Label
+										className={cn([
+											field.state.meta.errors.length
+												? "text-destructive"
+												: useAppDirectory
+													? "text-muted-foreground"
+													: "",
+											"w-fit",
+										])}
+										htmlFor="versionsParent"
+									>
+										Versions Parent Directory
+									</Label>
+								</TooltipTrigger>
+								<TooltipContent align="start" side="bottom">
+									<p className="text-xs">Defaults to the app data directory</p>
+									{field.state.meta.errors.length > 0 &&
+										field.state.meta.errors.map((error, index) => (
+											<p
+												className="text-destructive text-xs"
+												// biome-ignore lint/suspicious/noArrayIndexKey: Needed
+												key={index}
+											>
+												{error?.message}
+											</p>
+										))}
+								</TooltipContent>
+							</Tooltip>
+							<div className="flex gap-2">
+								<Input
+									className={
+										field.state.meta.errors.length ? "text-destructive" : ""
+									}
+									disabled={useAppDirectory || form.state.isSubmitting}
+									readOnly
+									value={
+										useAppDirectory ? `${appFolder}` : (field.state.value ?? "")
+									}
+								/>
+								<Button
+									disabled={form.state.isSubmitting || useAppDirectory}
+									onClick={() => handleBrowse("versionsParent")}
+									variant="outline"
+								>
+									Browse
+								</Button>
+							</div>
+						</div>
+					)}
+				</form.Field>
+				<form.Field name="streamMode">
+					{(field) => (
+						<div className="flex items-center gap-3">
+							<Checkbox
+								checked={field.state.value}
+								id="streamMode"
+								onCheckedChange={(checked) => {
+									field.handleChange(checked === true);
+								}}
+							/>
+							<Label htmlFor="streamMode">Enable Stream Mode</Label>
+						</div>
+					)}
+				</form.Field>
+				<form.Field name="darkMode">
+					{(field) => (
+						<div className="flex items-center gap-3">
+							<Checkbox
+								checked={field.state.value}
+								id="darkMode"
+								onCheckedChange={(checked) => {
+									field.handleChange(checked === true);
+								}}
+							/>
+							<Label htmlFor="darkMode">Enable Dark Mode</Label>
+						</div>
+					)}
+				</form.Field>
+				<form.Subscribe
+					selector={(s) => ({
+						isDefaultValue: s.isDefaultValue,
+						isSubmitting: s.isSubmitting,
+						isTouched: s.isTouched,
+						isValid: s.isValid,
+					})}
+				>
+					{(state) => (
+						<Button
+							disabled={
+								state.isSubmitting ||
+								!state.isTouched ||
+								!state.isValid ||
+								state.isDefaultValue
+							}
+							onClick={() => form.handleSubmit()}
+						>
+							Save Changes
+						</Button>
+					)}
+				</form.Subscribe>
+			</main>
+			<AlertDialog onOpenChange={setDialogOpen} open={dialogOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							How do you want to handle existing data?
+						</AlertDialogTitle>
+					</AlertDialogHeader>
+					<div className="space-y-2">
+						<Button
+							className="w-full"
+							onClick={() => handleDialogChoice("keep")}
+							variant="outline"
+						>
+							Keep current data (do not move or delete)
+						</Button>
+						<Button
+							className="w-full"
+							onClick={() => handleDialogChoice("delete")}
+							variant="destructive"
+						>
+							Delete current data from old location
+						</Button>
+						<Button
+							className="w-full"
+							onClick={() => handleDialogChoice("move")}
+							variant="default"
+						>
+							Copy current data to new location
+						</Button>
+					</div>
+					<AlertDialogFooter>
+						<Button onClick={() => setDialogOpen(false)} variant="ghost">
+							Cancel
+						</Button>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -3,7 +3,7 @@ import { appDataDir } from "@tauri-apps/api/path";
 import { createTauriStore } from "@tauri-store/zustand";
 import { create } from "zustand";
 
-type SetParentConfigProps = {
+export type SetParentConfigProps = {
 	deleteCurrentData: boolean;
 	moveCurrentData: boolean;
 };

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,32 @@
+import { createTauriStore } from "@tauri-store/zustand";
+import { create } from "zustand";
+
+type SettingsStore = {
+	darkMode: boolean;
+	toggleDarkMode: () => void;
+	installationsParent: string | undefined;
+	setInstallationsParent: (path: string | undefined) => void;
+	versionsParent: string | undefined;
+	setVersionsParent: (path: string | undefined) => void;
+	streamMode: boolean;
+	toggleStreamMode: () => void;
+};
+
+export const useSettingsStore = create<SettingsStore>()((set) => ({
+	darkMode: window.matchMedia?.("(prefers-color-scheme: dark)").matches,
+	installationsParent: undefined,
+	setInstallationsParent: (path) => set(() => ({ installationsParent: path })),
+	setVersionsParent: (path) => set(() => ({ versionsParent: path })),
+	streamMode: false,
+	toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+	toggleStreamMode: () => set((state) => ({ streamMode: !state.streamMode })),
+	versionsParent: undefined,
+}));
+
+export const tauriSettingsHandler = createTauriStore(
+	"settings",
+	useSettingsStore,
+	{
+		saveOnChange: true,
+	},
+);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,26 +1,67 @@
+import { invoke } from "@tauri-apps/api/core";
+import { appDataDir } from "@tauri-apps/api/path";
 import { createTauriStore } from "@tauri-store/zustand";
 import { create } from "zustand";
+
+type SetParentConfigProps = {
+	deleteCurrentData: boolean;
+	moveCurrentData: boolean;
+};
 
 type SettingsStore = {
 	darkMode: boolean;
 	toggleDarkMode: () => void;
-	installationsParent: string | undefined;
-	setInstallationsParent: (path: string | undefined) => void;
-	versionsParent: string | undefined;
-	setVersionsParent: (path: string | undefined) => void;
+	installationsParent: string | null;
+	setInstallationsParent: (
+		path: string | null,
+		config?: SetParentConfigProps,
+	) => Promise<void>;
+	versionsParent: string | null;
+	setVersionsParent: (
+		path: string | null,
+		config?: SetParentConfigProps,
+	) => Promise<void>;
 	streamMode: boolean;
 	toggleStreamMode: () => void;
 };
 
-export const useSettingsStore = create<SettingsStore>()((set) => ({
+export const useSettingsStore = create<SettingsStore>()((set, _get, store) => ({
 	darkMode: window.matchMedia?.("(prefers-color-scheme: dark)").matches,
-	installationsParent: undefined,
-	setInstallationsParent: (path) => set(() => ({ installationsParent: path })),
-	setVersionsParent: (path) => set(() => ({ versionsParent: path })),
+	installationsParent: null,
+	setInstallationsParent: async (path, config) => {
+		const appFolder = await appDataDir();
+		const installationsParent = store.getState().installationsParent;
+		if (config?.moveCurrentData) {
+			await invoke("move_installations_folder", {
+				destination: path ?? appFolder,
+				source: installationsParent ?? appFolder,
+			});
+		} else if (config?.deleteCurrentData) {
+			await invoke("remove_all_installations", {
+				source: installationsParent ?? appFolder,
+			});
+		}
+		set(() => ({ installationsParent: path }));
+	},
+	setVersionsParent: async (path, config) => {
+		const appFolder = await appDataDir();
+		const versionsParent = store.getState().versionsParent;
+		if (config?.moveCurrentData) {
+			await invoke("move_versions_folder", {
+				destination: path ?? appFolder,
+				source: versionsParent ?? appFolder,
+			});
+		} else if (config?.deleteCurrentData) {
+			await invoke("remove_all_versions", {
+				source: versionsParent ?? appFolder,
+			});
+		}
+		set(() => ({ versionsParent: path }));
+	},
 	streamMode: false,
 	toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
 	toggleStreamMode: () => set((state) => ({ streamMode: !state.streamMode })),
-	versionsParent: undefined,
+	versionsParent: null,
 }));
 
 export const tauriSettingsHandler = createTauriStore(


### PR DESCRIPTION
## Summary
- A few users have requested a few different changes, namely; stream mode to hide ip addresses on servers, changing where installations and versions gets downloaded to.

## Changes
- Ability to change dark mode (on/off)
- Ability to change where installations gets initialized
- Ability to change where versions gets downloaded to
- Ability to toggle stream mode (block server IP's)

## Related Issues
- Closes #65

## Screenshots
- Will be added later

## Checklist
- [x] I have linked related issues using #<number>
- [ ] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Additional Context
- Stream mode requested by Discord user Groblockia_