### PR TITLE
Fix/installation paths not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Resolves an issue where installation absolute paths don't get updated accordingly.
 
 ### Changed
 

--- a/src-tauri/src/modules/download.rs
+++ b/src-tauri/src/modules/download.rs
@@ -39,7 +39,7 @@ pub async fn download_and_maybe_extract<R: Runtime>(
     zipsubfolderprefix: Option<String>,
 ) -> Result<String, UiError> {
     let destpath = PathBuf::from(&destpath);
-    
+
     // Check if already installed (has vintagestory executable)
     if extract && destpath.exists() {
         let mut already_installed = false;
@@ -56,16 +56,17 @@ pub async fn download_and_maybe_extract<R: Runtime>(
                 }
             }
         }
-        
+
         if already_installed {
             return Ok("already_downloaded".into());
         } else {
             // Directory exists but no exe found - clean up partial installation
-            fs::remove_dir_all(&destpath)
-                .map_err(|e| UiError::from(format!("Failed to clean up incomplete installation: {e}")))?;
+            fs::remove_dir_all(&destpath).map_err(|e| {
+                UiError::from(format!("Failed to clean up incomplete installation: {e}"))
+            })?;
         }
     }
-    
+
     // 1) Download
     let resp = get(&url).await.map_err(|e| format!("request error: {e}"))?;
 

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -334,7 +334,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         // Now that we've ensured the path exists, open it
         if path.is_file() {
             // If it's a file, use /select to highlight it
@@ -363,7 +363,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         if path.is_dir() {
             Command::new("open")
                 .arg(&path.as_os_str())
@@ -388,7 +388,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         // Try xdg-open for general desktops.
         // For files, most DEs open the default app; to "reveal", try the folder.
         let target = if path.is_file() {
@@ -490,25 +490,18 @@ pub fn remove_installation(app: AppHandle, id: i64) -> Result<String, UiError> {
 pub async fn move_installations_folder(
     source: String,
     destination: String,
-) -> Result<String, UiError> {
+) -> Result<bool, UiError> {
     move_folder(
         std::path::PathBuf::from(source).join("installations"),
         std::path::PathBuf::from(destination).join("installations"),
-    )?;
-    Ok("moved".into())
+    )
 }
 
 #[command]
 pub async fn remove_all_installations(source: String) -> Result<String, UiError> {
     let source_path = std::path::PathBuf::from(source).join("installations");
     if !source_path.exists() || !source_path.is_dir() {
-        return Err(UiError {
-            name: "not_found".into(),
-            message: format!(
-                "Source installations directory not found: {}",
-                source_path.to_string_lossy()
-            ),
-        });
+        return Ok("not_exists".into());
     }
     std::fs::remove_dir_all(&source_path).map_err(|e| UiError {
         name: "remove_failed".into(),

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -35,13 +35,7 @@ pub fn installations_folder(app: AppHandle) -> PathBuf {
 
 pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bool, UiError> {
     if !source_path.exists() || !source_path.is_dir() {
-        return Err(UiError {
-            name: "not_found".into(),
-            message: format!(
-                "Source directory not found: {}",
-                source_path.to_string_lossy()
-            ),
-        });
+        return Ok(false);
     }
 
     let mut options = CopyOptions::new();

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -1,4 +1,4 @@
-use fs_extra::dir::{move_dir, CopyOptions};
+use fs_extra::dir::{copy, CopyOptions};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_zustand::ManagerExt;
@@ -34,19 +34,34 @@ pub fn installations_folder(app: AppHandle) -> PathBuf {
 }
 
 pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bool, UiError> {
+    if !destination_path.exists() {
+        std::fs::create_dir_all(&destination_path).map_err(|e| UiError {
+            name: "create_failed".into(),
+            message: format!("Failed to create destination directory: {e}"),
+        })?;
+    }
+
     if !source_path.exists() || !source_path.is_dir() {
         return Ok(false);
     }
 
-    let mut options = CopyOptions::new();
-    options.overwrite = true;
-    options.copy_inside = true;
-    options.skip_exist = true;
-
-    move_dir(&source_path, &destination_path, &options).map_err(|e| UiError {
-        name: "move_failed".into(),
-        message: format!("Failed to move directory: {e}"),
-    })?;
+    match std::fs::rename(&source_path, &destination_path) {
+        Ok(_) => return Ok(true),
+        Err(_) => {
+            let mut options = CopyOptions::new();
+            options.overwrite = true;
+            options.copy_inside = false;
+            let dst_parent = destination_path.parent().unwrap();
+            copy(&source_path, &dst_parent, &options).map_err(|e| UiError {
+                name: "move_failed".into(),
+                message: format!("Failed to move directory: {e}"),
+            })?;
+            std::fs::remove_dir_all(&source_path).map_err(|e| UiError {
+                name: "remove_failed".into(),
+                message: format!("Failed to remove source directory after move: {e}"),
+            })?;
+        }
+    }
 
     Ok(true)
 }

--- a/src-tauri/src/modules/versions.rs
+++ b/src-tauri/src/modules/versions.rs
@@ -72,12 +72,11 @@ pub async fn fetch_versions() -> Result<Vec<String>, UiError> {
 }
 
 #[command]
-pub async fn move_versions_folder(source: String, destination: String) -> Result<String, UiError> {
+pub async fn move_versions_folder(source: String, destination: String) -> Result<bool, UiError> {
     move_folder(
         std::path::PathBuf::from(source).join("versions"),
         std::path::PathBuf::from(destination).join("versions"),
-    )?;
-    Ok("moved".into())
+    )
 }
 
 #[command]
@@ -85,13 +84,7 @@ pub async fn remove_all_versions(source: String) -> Result<String, UiError> {
     let source_path = std::path::PathBuf::from(source).join("versions");
 
     if !source_path.exists() || !source_path.is_dir() {
-        return Err(UiError {
-            name: "not_found".into(),
-            message: format!(
-                "Source directory not found: {}",
-                source_path.to_string_lossy()
-            ),
-        });
+        return Ok("not_exists".into());
     }
 
     std::fs::remove_dir_all(&source_path).map_err(|e| UiError {

--- a/src/components/dialogs/addinstallation.dialog.tsx
+++ b/src/components/dialogs/addinstallation.dialog.tsx
@@ -91,9 +91,10 @@ export function AddInstallationDialog({ open }: { open: boolean }) {
 			id: Date.now(),
 			index: installations.length,
 			name: "",
-			path: appFolder
-				? `${appFolder}${pathDelimiter}installations${pathDelimiter}new`
-				: "",
+			path:
+				installationsParent || appFolder
+					? `${installationsParent ?? appFolder}${pathDelimiter}installations${pathDelimiter}new`
+					: "",
 			startParams: "",
 			version:
 				gameVersions

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -23,7 +23,8 @@ import {
 } from "@/components/ui/tooltip";
 import { useAppFolder } from "@/hooks/use-app-folder";
 import { installedVersionsQueryKey } from "@/hooks/use-installed-versions";
-import { cn } from "@/lib/utils";
+import { cn, pathDelimiter } from "@/lib/utils";
+import { useInstallationsStore } from "@/stores/installations";
 import { type SetParentConfigProps, useSettingsStore } from "@/stores/settings";
 
 export const Route = createFileRoute("/settings")({
@@ -39,6 +40,7 @@ const settingsSchema = z.object({
 
 function RouteComponent() {
 	const settingsStore = useSettingsStore();
+	const { updateInstallation, installations } = useInstallationsStore();
 	const { appFolder } = useAppFolder();
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [pendingField, setPendingField] = useState<
@@ -86,6 +88,18 @@ function RouteComponent() {
 				toast.success("Installations folder moved", {
 					id: "move-installations-folder",
 				});
+				// Update all installations paths
+				if (v.path !== null && configs?.installationsParent.moveCurrentData) {
+					installations.forEach((inst) => {
+						const oldPath = inst.path.split(
+							`${pathDelimiter}installations${pathDelimiter}`,
+						)[1];
+						if (!oldPath) return;
+						const newPath = `${v.path}${v.path?.endsWith(pathDelimiter) ? "" : pathDelimiter}installations${pathDelimiter}${oldPath}`;
+						const newInst = { ...inst, path: newPath };
+						updateInstallation(newInst);
+					});
+				}
 			}
 		},
 	});

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -40,7 +40,7 @@ const settingsSchema = z.object({
 
 function RouteComponent() {
 	const settingsStore = useSettingsStore();
-	const { updateParent } = useInstallationsStore();
+	const { updateParent, removeAll } = useInstallationsStore();
 	const { appFolder } = useAppFolder();
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [pendingField, setPendingField] = useState<
@@ -70,8 +70,16 @@ function RouteComponent() {
 			config?: SetParentConfigProps;
 		}) => settingsStore.setInstallationsParent(path, config),
 		onError: (error, v) => {
-			if (settingsStore.installationsParent !== v.path) {
+			if (v.config?.moveCurrentData) {
 				toast.error(`Failed to move installations folder: ${error.message}`, {
+					id: "move-installations-folder",
+				});
+			} else if (v.config?.deleteCurrentData) {
+				toast.error(`Failed to delete installations data: ${error.message}`, {
+					id: "move-installations-folder",
+				});
+			} else {
+				toast.error(`Failed to set installations folder: ${error.message}`, {
 					id: "move-installations-folder",
 				});
 			}
@@ -81,18 +89,34 @@ function RouteComponent() {
 				toast.loading("Moving installations folder...", {
 					id: "move-installations-folder",
 				});
+			} else if (v.config?.deleteCurrentData) {
+				toast.loading("Deleting installations data...", {
+					id: "move-installations-folder",
+				});
+			} else {
+				toast.loading("Setting installations folder...", {
+					id: "move-installations-folder",
+				});
 			}
 		},
-		onSuccess: (_, v) => {
-			if (settingsStore.installationsParent !== v.path) {
+		onSuccess: async (_, v) => {
+			if (v.config?.moveCurrentData) {
 				toast.success("Installations folder moved", {
 					id: "move-installations-folder",
 				});
 				// Update all installations paths
-				if (v.path !== null && configs?.installationsParent.moveCurrentData) {
-					updateParent(v.path);
-				}
+				updateParent(v.path ?? appFolder ?? "");
+			} else if (v.config?.deleteCurrentData) {
+				toast.success("Installations data deleted", {
+					id: "move-installations-folder",
+				});
+				removeAll();
+			} else if (settingsStore.installationsParent !== v.path) {
+				toast.success("Installations folder set", {
+					id: "move-installations-folder",
+				});
 			}
+			await queryClient.invalidateQueries({ queryKey: ["saves"] });
 		},
 	});
 
@@ -105,25 +129,54 @@ function RouteComponent() {
 			config?: SetParentConfigProps;
 		}) => settingsStore.setVersionsParent(path, config),
 		onError: (error, v) => {
-			if (settingsStore.versionsParent !== v.path) {
+			if (v.config?.moveCurrentData) {
 				toast.error(`Failed to move versions folder: ${error.message}`, {
+					id: "move-versions-folder",
+				});
+			} else if (v.config?.deleteCurrentData) {
+				toast.error(`Failed to delete versions data: ${error.message}`, {
+					id: "move-versions-folder",
+				});
+			} else {
+				toast.error(`Failed to set versions folder: ${error.message}`, {
 					id: "move-versions-folder",
 				});
 			}
 		},
 		onMutate: (v) => {
 			if (settingsStore.versionsParent !== v.path) {
-				toast.loading("Moving versions folder...", {
-					id: "move-versions-folder",
-				});
+				if (v.config?.moveCurrentData) {
+					toast.loading("Moving versions folder...", {
+						id: "move-versions-folder",
+					});
+				} else if (v.config?.deleteCurrentData) {
+					toast.loading("Deleting versions data...", {
+						id: "move-versions-folder",
+					});
+				} else {
+					toast.loading("Setting versions folder...", {
+						id: "move-versions-folder",
+					});
+				}
 			}
 		},
-		onSuccess: (_, v) => {
-			if (settingsStore.versionsParent !== v.path) {
+		onSuccess: async (_, v) => {
+			if (v.config?.moveCurrentData) {
 				toast.success("Versions folder moved", {
 					id: "move-versions-folder",
 				});
+			} else if (v.config?.deleteCurrentData) {
+				toast.success("Versions data deleted", {
+					id: "move-versions-folder",
+				});
+			} else if (settingsStore.versionsParent !== v.path) {
+				toast.success("Versions folder set", {
+					id: "move-versions-folder",
+				});
 			}
+			await queryClient.invalidateQueries({
+				queryKey: installedVersionsQueryKey(),
+			});
 		},
 	});
 
@@ -173,10 +226,6 @@ function RouteComponent() {
 			if (value.darkMode !== settingsStore.darkMode) {
 				settingsStore.toggleDarkMode();
 			}
-			await queryClient.invalidateQueries({ queryKey: ["saves"] });
-			await queryClient.invalidateQueries({
-				queryKey: installedVersionsQueryKey(),
-			});
 			toast.success("Settings saved");
 		},
 		validators: {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -85,7 +85,7 @@ function RouteComponent() {
 			}
 		},
 		onMutate: (v) => {
-			if (settingsStore.installationsParent !== v.path) {
+			if (v.config?.moveCurrentData) {
 				toast.loading("Moving installations folder...", {
 					id: "move-installations-folder",
 				});
@@ -111,7 +111,7 @@ function RouteComponent() {
 					id: "move-installations-folder",
 				});
 				removeAll();
-			} else if (settingsStore.installationsParent !== v.path) {
+			} else {
 				toast.success("Installations folder set", {
 					id: "move-installations-folder",
 				});
@@ -169,7 +169,7 @@ function RouteComponent() {
 				toast.success("Versions data deleted", {
 					id: "move-versions-folder",
 				});
-			} else if (settingsStore.versionsParent !== v.path) {
+			} else {
 				toast.success("Versions folder set", {
 					id: "move-versions-folder",
 				});

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -259,12 +259,15 @@ function RouteComponent() {
 		if (pendingField === "installationsParent") {
 			setConfigs({
 				installationsParent: config,
-				versionsParent: { deleteCurrentData: false, moveCurrentData: false },
+				versionsParent: configs?.versionsParent ?? {
+					deleteCurrentData: false,
+					moveCurrentData: false,
+				},
 			});
 			form.setFieldValue("installationsParent", pendingPath ?? "");
 		} else if (pendingField === "versionsParent") {
 			setConfigs({
-				installationsParent: {
+				installationsParent: configs?.installationsParent ?? {
 					deleteCurrentData: false,
 					moveCurrentData: false,
 				},

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useAppFolder } from "@/hooks/use-app-folder";
 import { installedVersionsQueryKey } from "@/hooks/use-installed-versions";
-import { cn, pathDelimiter } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { useInstallationsStore } from "@/stores/installations";
 import { type SetParentConfigProps, useSettingsStore } from "@/stores/settings";
 
@@ -40,7 +40,7 @@ const settingsSchema = z.object({
 
 function RouteComponent() {
 	const settingsStore = useSettingsStore();
-	const { updateInstallation, installations } = useInstallationsStore();
+	const { updateParent } = useInstallationsStore();
 	const { appFolder } = useAppFolder();
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [pendingField, setPendingField] = useState<
@@ -90,15 +90,7 @@ function RouteComponent() {
 				});
 				// Update all installations paths
 				if (v.path !== null && configs?.installationsParent.moveCurrentData) {
-					installations.forEach((inst) => {
-						const oldPath = inst.path.split(
-							`${pathDelimiter}installations${pathDelimiter}`,
-						)[1];
-						if (!oldPath) return;
-						const newPath = `${v.path}${v.path?.endsWith(pathDelimiter) ? "" : pathDelimiter}installations${pathDelimiter}${oldPath}`;
-						const newInst = { ...inst, path: newPath };
-						updateInstallation(newInst);
-					});
+					updateParent(v.path);
 				}
 			}
 		},

--- a/src/stores/installations.ts
+++ b/src/stores/installations.ts
@@ -1,6 +1,7 @@
 import { createTauriStore } from "@tauri-store/zustand";
 import { toast } from "sonner";
 import { create } from "zustand/react";
+import { makeStringFolderSafe, pathDelimiter } from "@/lib/utils";
 
 export type Installation = {
 	id: number;
@@ -33,6 +34,7 @@ type InstallationsStore = {
 	) => void;
 	moveInstallation: (id: number, newIndex: number) => void;
 	toggleFavorite: (id: number) => void;
+	updateParent: (newPath: string) => void;
 };
 
 export const useInstallationsStore = create<InstallationsStore>((set) => ({
@@ -139,6 +141,13 @@ export const useInstallationsStore = create<InstallationsStore>((set) => ({
 				inst.id === id ? { ...inst, lastTimePlayed: Date.now() } : inst,
 			),
 		})),
+	updateParent: (newPath: string) =>
+		set((state) => ({
+			installations: state.installations.map((inst) => ({
+				...inst,
+				path: `${newPath}${newPath.endsWith(pathDelimiter) ? "" : pathDelimiter}installations${pathDelimiter}${makeStringFolderSafe(inst.name)}`,
+			})),
+		})),
 }));
 
 export const useInstallations = () => {
@@ -152,6 +161,7 @@ export const useInstallations = () => {
 		setSelectedInstallation,
 		toggleFavorite,
 		updateLastPlayed,
+		updateParent,
 	} = useInstallationsStore();
 
 	const outInstallations = [...installations]
@@ -168,6 +178,7 @@ export const useInstallations = () => {
 		toggleFavorite,
 		updateInstallation,
 		updateLastPlayed,
+		updateParent,
 	};
 };
 

--- a/src/stores/installations.ts
+++ b/src/stores/installations.ts
@@ -35,6 +35,7 @@ type InstallationsStore = {
 	moveInstallation: (id: number, newIndex: number) => void;
 	toggleFavorite: (id: number) => void;
 	updateParent: (newPath: string) => void;
+	removeAll: () => void;
 };
 
 export const useInstallationsStore = create<InstallationsStore>((set) => ({
@@ -89,6 +90,7 @@ export const useInstallationsStore = create<InstallationsStore>((set) => ({
 			}));
 			return { ...state, installations: reindexed };
 		}),
+	removeAll: () => set({ installations: [], selectedInstallation: null }),
 	removeInstallation: (id) =>
 		set((state) => ({
 			installations: state.installations.filter((inst) => inst.id !== id),
@@ -162,6 +164,7 @@ export const useInstallations = () => {
 		toggleFavorite,
 		updateLastPlayed,
 		updateParent,
+		removeAll,
 	} = useInstallationsStore();
 
 	const outInstallations = [...installations]
@@ -172,6 +175,7 @@ export const useInstallations = () => {
 		addInstallation,
 		installations: outInstallations,
 		moveInstallation,
+		removeAll,
 		removeInstallation,
 		selectedInstallation,
 		setSelectedInstallation,


### PR DESCRIPTION
## Summary
- There's an issue where it doesn't update all the absolute installation paths, when changing to a new installations parent.

## Changes
- Fix the issue where it doesn't update the installation paths when changing the path

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings