### PR TITLE
Fix/imported clientsettings not containing mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Resolve an issue where modPaths don't get updated accordingly when clientsettings.json gets imported.
 
 ### Changed
 

--- a/src-tauri/src/modules/download.rs
+++ b/src-tauri/src/modules/download.rs
@@ -39,7 +39,7 @@ pub async fn download_and_maybe_extract<R: Runtime>(
     zipsubfolderprefix: Option<String>,
 ) -> Result<String, UiError> {
     let destpath = PathBuf::from(&destpath);
-    
+
     // Check if already installed (has vintagestory executable)
     if extract && destpath.exists() {
         let mut already_installed = false;
@@ -56,16 +56,17 @@ pub async fn download_and_maybe_extract<R: Runtime>(
                 }
             }
         }
-        
+
         if already_installed {
             return Ok("already_downloaded".into());
         } else {
             // Directory exists but no exe found - clean up partial installation
-            fs::remove_dir_all(&destpath)
-                .map_err(|e| UiError::from(format!("Failed to clean up incomplete installation: {e}")))?;
+            fs::remove_dir_all(&destpath).map_err(|e| {
+                UiError::from(format!("Failed to clean up incomplete installation: {e}"))
+            })?;
         }
     }
-    
+
     // 1) Download
     let resp = get(&url).await.map_err(|e| format!("request error: {e}"))?;
 

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -144,6 +144,27 @@ pub fn play_game(app: AppHandle, options: Option<PlayGameParams>) -> Result<Stri
                 } else {
                     obj.insert("stringSettings".into(), settings["stringSettings"].clone());
                 }
+                let mods_path = pb.join("Mods").to_string_lossy().into_owned();
+                if let Some(string_list_settings) = obj
+                    .get_mut("stringListSettings")
+                    .and_then(|v| v.as_object_mut())
+                {
+                    if let Some(mod_paths) = string_list_settings
+                        .get_mut("modPaths")
+                        .and_then(|v| v.as_array_mut())
+                    {
+                        if !mod_paths.iter().any(|p| p.as_str() == Some(&mods_path)) {
+                            mod_paths.push(json!(mods_path));
+                        }
+                    } else {
+                        string_list_settings.insert("modPaths".into(), json!([mods_path]));
+                    }
+                } else {
+                    obj.insert(
+                        "stringListSettings".into(),
+                        json!({ "modPaths": [mods_path, "Mods"] }),
+                    );
+                }
             }
             std::fs::write(
                 &settings_path,
@@ -334,7 +355,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         // Now that we've ensured the path exists, open it
         if path.is_file() {
             // If it's a file, use /select to highlight it
@@ -363,7 +384,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         if path.is_dir() {
             Command::new("open")
                 .arg(&path.as_os_str())
@@ -388,7 +409,7 @@ pub fn reveal_in_file_explorer(path: String) -> Result<String, UiError> {
                 message: format!("Failed to create directory: {e}"),
             })?;
         }
-        
+
         // Try xdg-open for general desktops.
         // For files, most DEs open the default app; to "reveal", try the folder.
         let target = if path.is_file() {

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -153,11 +153,9 @@ pub fn play_game(app: AppHandle, options: Option<PlayGameParams>) -> Result<Stri
                         .get_mut("modPaths")
                         .and_then(|v| v.as_array_mut())
                     {
-                        if !mod_paths.iter().any(|p| p.as_str() == Some(&mods_path)) {
-                            mod_paths.push(json!(mods_path));
-                        }
+                        *mod_paths = vec![json!(mods_path), json!("Mods")];
                     } else {
-                        string_list_settings.insert("modPaths".into(), json!([mods_path]));
+                        string_list_settings.insert("modPaths".into(), json!([mods_path, "Mods"]));
                     }
                 } else {
                     obj.insert(


### PR DESCRIPTION
## Summary
- When importing the clientsettings from a previous installation, it wouldn't contain the new mods folder link

## Changes
- Fixes that the mod paths don't contain the new mods folder

## Related Issues
- Issue on Discord

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings