### PR TITLE
Fix/mod not linking correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Resolve an issue where mods were linking to the Mod site homepage.
 
 ### Changed
 

--- a/src/components/dialogs/updatemod.dialog.tsx
+++ b/src/components/dialogs/updatemod.dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { installedModsQueryKey } from "@/hooks/use-installed-mods";
 import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import type { ProgressPayload } from "@/lib/types";
+import { pathDelimiter } from "@/lib/utils";
 import type { OutputMod } from "@/routes/install-mods/$id";
 import { useDialogStore } from "@/stores/dialogs";
 import type { Installation } from "@/stores/installations";
@@ -114,7 +115,7 @@ export function UpdateModDialog({
 			},
 			onSuccess: () => {
 				addModToInstallation({
-					path: `${installation.path}/Mods`,
+					path: `${installation.path}${pathDelimiter}Mods`,
 					url: selectedVersion?.mainfile || "",
 				});
 			},

--- a/src/components/items/mod.item.tsx
+++ b/src/components/items/mod.item.tsx
@@ -150,7 +150,7 @@ export function ModItem({
 		>
 			<div className="flex flex-row gap-2">
 				<a
-					href={`https://mods.vintagestory.at/${mod.urlalias ?? "#"}`}
+					href={`https://mods.vintagestory.at/${mod.urlalias ?? `show/mod/${mod.assetid}`}`}
 					rel="noreferrer"
 					target="_blank"
 				>
@@ -167,7 +167,7 @@ export function ModItem({
 					<div className="flex gap-1 items-center">
 						<a
 							className="hover:underline font-semibold"
-							href={`https://mods.vintagestory.at/${mod.urlalias ?? "#"}`}
+							href={`https://mods.vintagestory.at/${mod.urlalias ?? `show/mod/${mod.assetid}`}`}
 							rel="noreferrer"
 							target="_blank"
 						>

--- a/src/components/items/mod.item.tsx
+++ b/src/components/items/mod.item.tsx
@@ -25,7 +25,7 @@ import {
 	modUpdatesQueryKey,
 } from "@/hooks/use-mod-updates";
 import type { ModInfo, ProgressPayload } from "@/lib/types";
-import { cn, compareSemverAsc } from "@/lib/utils";
+import { cn, compareSemverAsc, pathDelimiter } from "@/lib/utils";
 import type { OutputMod } from "@/routes/install-mods/$id";
 import { useDialogStore } from "@/stores/dialogs";
 import type { Installation } from "@/stores/installations";
@@ -54,6 +54,7 @@ export function ModItem({
 	const updateMod =
 		modUpdates?.updates[mod.modidstrs[0]] ??
 		modUpdates?.updates[mod.modid.toString()] ??
+		modUpdates?.updates[mod.assetid.toString()] ??
 		modUpdates?.updates[mod.urlalias ?? ""];
 	const { data: modInfo } = useQuery({
 		enabled: !!updateMod,
@@ -84,7 +85,7 @@ export function ModItem({
 			},
 			onSuccess: () => {
 				addModToInstallation({
-					path: `${installation?.path}/Mods`,
+					path: `${installation?.path}${pathDelimiter}Mods`,
 					url: updateMod?.mainfile || "",
 				});
 			},
@@ -248,7 +249,7 @@ export function ModItem({
 								disabled={isDownloading}
 								onClick={() =>
 									downloadLatestModVersion({
-										path: `${installation.path}/Mods`,
+										path: `${installation.path}${pathDelimiter}Mods`,
 									})
 								}
 								size="icon"

--- a/src/hooks/use-add-mod-to-installation.ts
+++ b/src/hooks/use-add-mod-to-installation.ts
@@ -1,6 +1,7 @@
 import { type UseMutationOptions, useMutation } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import type { ModInfo } from "@/lib/types";
+import { pathDelimiter } from "@/lib/utils";
 import type { Installation } from "@/stores/installations";
 
 export const useAddModToInstallation = (
@@ -19,7 +20,7 @@ export const useAddModToInstallation = (
 		...props,
 		mutationFn: async ({ installation, mod: { mod }, version, emitevent }) =>
 			invoke("download_and_maybe_extract", {
-				destpath: `${installation.path}/Mods`,
+				destpath: `${installation.path}${pathDelimiter}Mods`,
 				emitevent,
 				extract: false,
 				url: mod.releases.find((r) => r.modversion === version)?.mainfile,


### PR DESCRIPTION
## Summary
- When clicking on a mod in the mods page, it would sometimes go to the Mod site's homepage, instead of the Mod's site.

## Changes
- Change how we detect and display the url.

## Related Issues
- Fixes an issue reported on Discord by user Groblockia_

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings