### PR TITLE
chore(workflow): ✨ add Rust caching step to bump version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -18,6 +18,11 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:


### PR DESCRIPTION
## Summary
- Add rust caching step to bump version workflow

## Changes
- Introduced a caching step for Rust dependencies to improve build performance.
- Utilizes `swatinem/rust-cache@v2` to cache the workspace from `./src-tauri` to `target`.

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings