### PR TITLE
refactor(mod): 🔄 improve `ModItem` and `ModList` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up code handling paths to make the application more robust.
 - Sorting algorithm for installations, to make the sorting consistent across pages.
 
+### Fixed
+
+- Resolve an issue with mod updating, where it wouldn't instantly show you if an update is available.
+
 ### Removed
 
 - Drag and drop functionality for servers and installations.

--- a/src/components/items/mod.item.tsx
+++ b/src/components/items/mod.item.tsx
@@ -56,10 +56,12 @@ export function ModItem({
 	const { data: modInfo } = useQuery({
 		enabled: !!updateMod,
 		queryFn: () =>
-			invoke("fetch_mod_info", {
+			updateMod &&
+			(invoke("fetch_mod_info", {
 				modid: updateMod?.modidstr,
-			}) as Promise<ModInfo>,
+			}) as Promise<ModInfo>),
 		queryKey: ["modInfo", mod.modid],
+		refetchOnMount: false,
 		refetchOnReconnect: false,
 		refetchOnWindowFocus: false,
 	});

--- a/src/components/lists/mod.list.tsx
+++ b/src/components/lists/mod.list.tsx
@@ -44,7 +44,7 @@ export function ModList({
 	installation,
 }: {
 	parentRef: React.RefObject<HTMLDivElement | null>;
-	installation: Installation | null;
+	installation: Installation;
 }) {
 	const {
 		searchText,
@@ -62,13 +62,11 @@ export function ModList({
 			versions: selectedGameVersions.map((version) => version),
 		}),
 	);
-	const { data: instMods } = useInstalledMods(installation?.path ?? "", {
-		enabled: !!installation,
-	});
+	const { data: instMods } = useInstalledMods(installation.path);
 	const installedMods = instMods?.mods ?? [];
 	const { data: modUpdates } = useModUpdates(
 		{
-			installationId: installation?.id ?? -1,
+			installationId: installation.id,
 			params:
 				installedMods?.map((mod) => `${mod.modid}@${mod.version}`).join(",") ??
 				"",

--- a/src/hooks/use-mod-updates.ts
+++ b/src/hooks/use-mod-updates.ts
@@ -18,13 +18,13 @@ export type ModUpdatesResponse = {
 	};
 };
 
-export const modUpdatesQueryKey = (installationId: number | null) => [
-	"modUpdates",
-	installationId,
-];
+export const modUpdatesQueryKey = (installationId: number, params?: string) =>
+	params !== undefined
+		? ["modUpdates", installationId, params]
+		: ["modUpdates", installationId];
 
 export const useModUpdates = (
-	{ installationId, params }: { installationId: number | null; params: string },
+	{ installationId, params }: { installationId: number; params: string },
 	props?: Omit<
 		UseQueryOptions<ModUpdatesResponse, Error, ModUpdatesResponse>,
 		"queryKey" | "queryFn"
@@ -33,7 +33,7 @@ export const useModUpdates = (
 	return useQuery({
 		queryFn: () =>
 			invoke("get_mod_updates", { params }) as Promise<ModUpdatesResponse>,
-		queryKey: modUpdatesQueryKey(installationId),
+		queryKey: modUpdatesQueryKey(installationId, params),
 		...props,
 	});
 };


### PR DESCRIPTION
## Summary
- Change the way updating a mod works, so that it instantly shows if there's an update available.

## Changes
- Simplified the query function in `ModItem` to only invoke when `updateMod` is defined.
- Updated `installation` type in `ModList` to be non-nullable for better type safety.
- Enhanced `useModUpdates` to ensure `installationId` is always a number.

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings