### PR TITLE
feat: cancel version downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduced a "Cancel" button for version downloads.
+
 ### Fixed
 
 - Resolve an issue where dark mode was not being enabled/disabled instantly, when switching.

--- a/src-tauri/src/modules/download.rs
+++ b/src-tauri/src/modules/download.rs
@@ -8,8 +8,12 @@ use std::{
     io::{self, Seek, Write},
     path::{Path, PathBuf},
     process::Command,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
-use tauri::{command, Emitter, Runtime};
+use tauri::{command, Emitter, Listener, Runtime};
 
 use super::errors::UiError;
 
@@ -39,6 +43,13 @@ pub async fn download_and_maybe_extract<R: Runtime>(
     zipsubfolderprefix: Option<String>,
 ) -> Result<String, UiError> {
     let destpath = PathBuf::from(&destpath);
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_clone = cancelled.clone();
+    let cancel_event_name = format!("{}:cancel", emitevent);
+    let listener_id = app.listen(&cancel_event_name, move |_evt| {
+        cancel_clone.store(true, Ordering::SeqCst);
+    });
 
     // Check if already installed (has vintagestory executable)
     if extract && destpath.exists() {
@@ -114,6 +125,25 @@ pub async fn download_and_maybe_extract<R: Runtime>(
     let mut downloaded: u64 = 0;
 
     while let Some(chunk) = stream.next().await {
+        if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
+            let _ = fs::remove_file(filepath);
+            let _ = fs::remove_dir_all(&destpath);
+            app.emit(
+                &emitevent,
+                ProgressPayload {
+                    phase: "cancelled",
+                    downloaded: Some(downloaded),
+                    total,
+                    percent: None,
+                    current: None,
+                    count: None,
+                    message: Some("Download cancelled".into()),
+                },
+            )
+            .ok();
+            app.unlisten(listener_id);
+            return Ok("cancelled".into());
+        }
         let chunk = chunk.map_err(|e| format!("stream error: {e}"))?;
         file.write_all(&chunk)
             .map_err(|e| format!("file write error: {e}"))?;
@@ -185,6 +215,26 @@ pub async fn download_and_maybe_extract<R: Runtime>(
                 .map_err(|e| UiError::from(format!("zip open error: {e}")))?;
 
             for i in 0..archive.len() {
+                if cancelled.load(Ordering::SeqCst) {
+                    // Optional: cleanup extraction dir
+                    let _ = fs::remove_dir_all(&destpath);
+                    let _ = fs::remove_file(filepath);
+                    app.emit(
+                        &emitevent,
+                        ProgressPayload {
+                            phase: "cancelled",
+                            downloaded: None,
+                            total: None,
+                            percent: None,
+                            current: None,
+                            count: None,
+                            message: Some("Extraction cancelled".into()),
+                        },
+                    )
+                    .ok();
+                    app.unlisten(listener_id);
+                    return Ok("cancelled".into());
+                }
                 let mut entry = archive
                     .by_index(i)
                     .map_err(|e| UiError::from(format!("zip index error: {e}")))?;
@@ -304,6 +354,25 @@ pub async fn download_and_maybe_extract<R: Runtime>(
             .map_err(|e| UiError::from(format!("tar error: {e}")))?;
             if !status.success() {
                 return Err(UiError::from(format!("tar failed: {}", status)));
+            }
+            if cancelled.load(Ordering::SeqCst) {
+                let _ = fs::remove_dir_all(&destpath);
+                let _ = fs::remove_file(filepath);
+                app.emit(
+                    &emitevent,
+                    ProgressPayload {
+                        phase: "cancelled",
+                        downloaded: None,
+                        total: None,
+                        percent: None,
+                        current: None,
+                        count: None,
+                        message: Some("Extraction cancelled".into()),
+                    },
+                )
+                .ok();
+                app.unlisten(listener_id);
+                return Ok("cancelled".into());
             }
             // Remove the downloaded archive after extraction
             fs::remove_file(filepath)

--- a/src/hooks/use-download-version.ts
+++ b/src/hooks/use-download-version.ts
@@ -4,7 +4,7 @@ import {
 	useQueryClient,
 } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useRef } from "react";
 import { toast } from "sonner";
 import type { ProgressPayload } from "@/lib/types";
@@ -49,12 +49,18 @@ export const useDownloadVersion = (
 		mutationKey: ["download-version"],
 		onError: (error, v) => {
 			toast.error(`Error downloading game version: ${error.message}`, {
+				action: undefined,
 				id: `download-game-version-${v}`,
 			});
 			listenRef.current?.();
 		},
 		onMutate: async (v) => {
 			toast.loading(`Starting to download game version ${v}...`, {
+				action: {
+					label: "Cancel",
+					onClick: () =>
+						emit(`download://version:${v.replace(/\./g, "_")}:cancel`),
+				},
 				id: `download-game-version-${v}`,
 			});
 			listenRef.current = await listen<ProgressPayload>(
@@ -65,11 +71,21 @@ export const useDownloadVersion = (
 						toast.loading(
 							`Downloading game version ${v}: ${percent?.toFixed(0)}%`,
 							{
+								action: {
+									label: "Cancel",
+									onClick: () =>
+										emit(`download://version:${v.replace(/\./g, "_")}:cancel`),
+								},
 								id: `download-game-version-${v}`,
 							},
 						);
 					} else if (phase === "extract") {
 						toast.loading(`Extracting game version ${v}...`, {
+							action: {
+								label: "Cancel",
+								onClick: () =>
+									emit(`download://version:${v.replace(/\./g, "_")}:cancel`),
+							},
 							id: `download-game-version-${v}`,
 						});
 					}
@@ -82,12 +98,22 @@ export const useDownloadVersion = (
 				toast.dismiss(`download-game-version-${v}`);
 				return;
 			}
+			if (d === "cancelled") {
+				toast.info(`Download of game version ${v} cancelled`, {
+					action: undefined,
+					id: `download-game-version-${v}-cancelled`,
+				});
+				return;
+			}
 			await queryClient.invalidateQueries({
 				queryKey: installedVersionsQueryKey(),
 			});
-			toast.success(`Game version ${v} downloaded`, {
-				id: `download-game-version-${v}`,
-			});
+			if (d === "success") {
+				toast.success(`Game version ${v} downloaded`, {
+					action: undefined,
+					id: `download-game-version-${v}`,
+				});
+			}
 		},
 		scope: {
 			id: "download-version",


### PR DESCRIPTION
## Summary
- Introduce a cancel version download.

## Changes
- Add the ability to cancel version downloads/extracts, which removes the download file & the destination path.

## Related Issues
- Closes #68 

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings