### PR TITLE
feat(installations): ✨ add `rename_installations_folder` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resolve an issue where dark mode was not being enabled/disabled instantly, when switching.
+- Resolve an issue where it would just create an empty folder, when renaming an installation.
 
 ## [0.5.2] - 2025-10-28
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,7 @@ pub fn run() {
             installations::remove_installation,
             installations::move_installations_folder,
             installations::remove_all_installations,
+            installations::rename_installations_folder,
             // Servers
             servers::fetch_public_servers,
             servers::fetch_all_servers,

--- a/src-tauri/src/modules/installations.rs
+++ b/src-tauri/src/modules/installations.rs
@@ -17,7 +17,7 @@ use tauri_plugin_zustand::ManagerExt;
 use walkdir::WalkDir;
 
 use super::errors::UiError;
-use super::utils::{move_folder, versions_folder, versions_subdir};
+use super::utils::{installations_subdir, move_folder, versions_folder, versions_subdir};
 
 #[command]
 pub async fn initialize_game(path: String) -> Result<String, UiError> {
@@ -498,6 +498,26 @@ pub fn remove_installation(app: AppHandle, id: i64) -> Result<String, UiError> {
             message: format!("Installation with id {} not found", id),
         })
     }
+}
+
+#[command]
+pub async fn rename_installations_folder(
+    app: AppHandle,
+    source: String,
+    new_name: String,
+    subdir: String,
+) -> Result<String, UiError> {
+    let source_path = PathBuf::from(source)
+        .join(installations_subdir(app))
+        .join(&subdir);
+    let destination_path = source_path
+        .parent()
+        .ok_or_else(|| UiError {
+            name: "invalid_path".into(),
+            message: "Source path has no parent directory".into(),
+        })?
+        .join(new_name);
+    move_folder(source_path, destination_path)
 }
 
 #[command]

--- a/src-tauri/src/modules/utils.rs
+++ b/src-tauri/src/modules/utils.rs
@@ -1,6 +1,6 @@
 use fs_extra::dir::{copy, CopyOptions};
 use std::{
-    fs::{create_dir_all, remove_dir_all, rename},
+    fs::{remove_dir_all, rename},
     path::PathBuf,
 };
 use tauri::{AppHandle, Manager};
@@ -48,28 +48,22 @@ pub fn installations_subdir(app: AppHandle) -> String {
         .unwrap_or_else(|_| "installations".to_string())
 }
 
-pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bool, UiError> {
-    if !destination_path.exists() {
-        create_dir_all(&destination_path).map_err(|e| UiError {
-            name: "create_failed".into(),
-            message: format!("Failed to create destination directory: {e}"),
-        })?;
-    }
-
+pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<String, UiError> {
     if !source_path.exists() || !source_path.is_dir() {
-        return Ok(false);
+        return Ok("source_not_exist".into());
     }
 
     match rename(&source_path, &destination_path) {
-        Ok(_) => return Ok(true),
+        Ok(_) => return Ok("renamed".into()),
         Err(_) => {
             let mut options = CopyOptions::new();
             options.overwrite = true;
             options.copy_inside = false;
-            let dst_parent = destination_path.parent().unwrap();
-            copy(&source_path, dst_parent, &options).map_err(|e| UiError {
-                name: "move_failed".into(),
-                message: format!("Failed to move directory: {e}"),
+            copy(&source_path, destination_path.parent().unwrap(), &options).map_err(|e| {
+                UiError {
+                    name: "move_failed".into(),
+                    message: format!("Failed to move directory: {e}"),
+                }
             })?;
             remove_dir_all(&source_path).map_err(|e| UiError {
                 name: "remove_failed".into(),
@@ -78,5 +72,5 @@ pub fn move_folder(source_path: PathBuf, destination_path: PathBuf) -> Result<bo
         }
     }
 
-    Ok(true)
+    Ok("moved".into())
 }

--- a/src/components/dialogs/editinstallation.dialog.tsx
+++ b/src/components/dialogs/editinstallation.dialog.tsx
@@ -1,5 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
 import clsx from "clsx";
 import { useId } from "react";
 import { Button } from "@/components/ui/button";
@@ -87,7 +88,21 @@ export function EditInstallationDialog({
 					totalTimePlayed: installation.totalTimePlayed,
 					version: value.version,
 				},
-				(status) => status && closeDialog(),
+				async (status) => {
+					if (status) {
+						const safeName = makeStringFolderSafe(value.name);
+						const oldSafeName = makeStringFolderSafe(installation.name);
+						if (safeName === oldSafeName) {
+							return;
+						}
+						await invoke("rename_installations_folder", {
+							newName: safeName,
+							source: installationsParent ?? appFolder ?? "",
+							subdir: oldSafeName,
+						});
+						closeDialog();
+					}
+				},
 			);
 		},
 		validators: {


### PR DESCRIPTION
## Summary
- Resolve an issue with renaming installations, where it would then not go ahead and move all the files inside the installation.

## Changes
- Implemented a new command to rename installation folders.
- Updated the `move_folder` function to return meaningful status messages.
- Modified the `EditInstallationDialog` to invoke the new command on form submission.

## Related Issues
- Resolves an issue reported on Github by user Groblockia_

## Checklist
- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings