### PR TITLE
fix: 🐛 exportInstallation uses React hook (useInstalledMods) outside component context

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
 import { platform } from "@tauri-apps/plugin-os";
 import { type ClassValue, clsx } from "clsx";
 import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
-import { useInstalledMods } from "@/hooks/use-installed-mods";
+import type { OutputMod } from "@/routes/install-mods/$id";
 import type { Installation } from "@/stores/installations";
 
 export function cn(...inputs: ClassValue[]) {
@@ -139,9 +140,11 @@ export const exportInstallation = async ({
 }: {
 	installation: Installation;
 }) => {
-	const { data: installationMods } = useInstalledMods(installation.path);
+	const installationMods = await invoke<{ mods: OutputMod[] }>("get_mods", {
+		path: installation.path,
+	});
 	const data = {
-		mods: installationMods?.mods.map((m) => ({
+		mods: installationMods.mods.map((m) => ({
 			id: m.modid,
 			version: m.version,
 		})),


### PR DESCRIPTION
## Summary
- Fixes `exportInstallation` failing at runtime due to calling a React hook (`useInstalledMods`) outside of a component context.
- Replaces the hook call with a direct `invoke("get_mods", ...)` Tauri command, which is the same underlying data source the hook wraps.

## Changes
- **`src/lib/utils.ts`**: Replaced `useInstalledMods(installation.path)` with `await invoke<{ mods: OutputMod[] }>("get_mods", { path: installation.path })`. Updated imports accordingly (`invoke` from `@tauri-apps/api/core`, `OutputMod` type).

## Related Issues
- May be related to #119 
- Issue mentioned in the StoryForge discord server: [https://discord.com/channels/1418169122914832456/1419979519258923039/1450350566084444200](https://discord.com/channels/1418169122914832456/1419979519258923039/1450350566084444200)

## Screenshots / Demos (if applicable)
N/A — no UI changes. The export installation button now works correctly instead of doing nothing.

## Checklist
- [x] I have linked related issues using #\<number\>
- [ ] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Breaking Changes (if any)
None. The `exportInstallation` function signature is unchanged. Only the internal data-fetching mechanism was replaced.

## Additional Context
- `useInstalledMods` is a `useSuspenseQuery` wrapper around the `get_mods` Tauri command. React hooks cannot be called outside component/hook context, making a direct `invoke` the correct approach for a standalone utility function.
- The hook itself is still used and works correctly in `install-mods/$id.tsx` and `mod.list.tsx`.

## Reviewers
- @LovelessCodes