### PR TITLE
feat: add standalone map viewing support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,10 +79,13 @@ pub fn run() {
             saves::update_world,
             saves::remove_world,
             // Maps
+            maps::get_all_maps,
             maps::inspect_map_database,
             maps::get_map_bounds,
+            maps::get_map_bounds_by_path,
             maps::get_map_tile,
             maps::get_all_map_tiles,
+            maps::get_all_map_tiles_by_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/maps.rs
+++ b/src-tauri/src/modules/maps.rs
@@ -3,13 +3,24 @@ use prost::Message;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 use std::{
+    fs::read_dir,
     io::Cursor,
     path::{Path, PathBuf},
 };
-use tauri::command;
+use tauri::{command, AppHandle};
 
 use super::errors::UiError;
 use super::proto::{GameData, MapPieceDb};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MapInfo {
+    pub id: u64,
+    pub name: String,
+    pub installation_id: u64,
+    pub installation_name: String,
+    pub path: String,
+    pub size_bytes: u64,
+}
 
 /// Information about the Maps database structure
 #[derive(Serialize, Deserialize, Debug)]
@@ -114,6 +125,83 @@ fn get_maps_db_path(world_path: &str) -> Result<PathBuf, UiError> {
     }
 
     Ok(maps_path)
+}
+
+/// Scan all installations for Maps databases
+#[command]
+pub fn get_all_maps(app: AppHandle) -> Result<Vec<MapInfo>, UiError> {
+    use super::utils::{installations_folder, installations_subdir};
+    use std::fs::metadata;
+
+    let subdir = installations_subdir(app.clone());
+    let installations_dir = installations_folder(app.clone()).join(&subdir);
+    let mut maps = Vec::new();
+
+    if !installations_dir.is_dir() {
+        return Ok(maps);
+    }
+
+    for entry in read_dir(&installations_dir).map_err(|e| UiError {
+        name: "io_error".into(),
+        message: format!("Failed to read installations dir: {e}"),
+    })? {
+        let entry = entry.map_err(|e| UiError {
+            name: "io_error".into(),
+            message: format!("Dir entry error: {e}"),
+        })?;
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let inst_name = entry.file_name().to_string_lossy().to_string();
+        let inst_id = super::installations::generate_id(&inst_name);
+
+        let maps_dir = dir.join("Maps");
+        if !maps_dir.is_dir() {
+            continue;
+        }
+
+        for map_entry in read_dir(&maps_dir).map_err(|e| UiError {
+            name: "io_error".into(),
+            message: format!("Failed to read Maps dir: {e}"),
+        })? {
+            let map_entry = map_entry.map_err(|e| UiError {
+                name: "io_error".into(),
+                message: format!("Map entry error: {e}"),
+            })?;
+            let map_path = map_entry.path();
+            if !map_path.is_file() {
+                continue;
+            }
+            if map_path.extension().and_then(|e| e.to_str()) != Some("db") {
+                continue;
+            }
+            let name = map_path
+                .file_stem()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let size_bytes = metadata(&map_path).map(|m| m.len()).unwrap_or(0);
+
+            // Generate id from installation_name + map_name
+            let combined = format!("{}|{}", inst_name, name);
+            let mut hash: u32 = 0x811c9dc5;
+            for byte in combined.bytes() {
+                hash ^= byte as u32;
+                hash = hash.wrapping_mul(0x01000193);
+            }
+
+            maps.push(MapInfo {
+                id: hash as u64,
+                name,
+                installation_id: inst_id,
+                installation_name: inst_name.clone(),
+                path: map_path.to_string_lossy().to_string(),
+                size_bytes,
+            });
+        }
+    }
+
+    Ok(maps)
 }
 
 /// Inspect the Maps database for a given world
@@ -487,4 +575,104 @@ fn detect_image_dimensions(data: &[u8]) -> Option<(u32, u32)> {
         .ok()?;
     let dimensions = reader.into_dimensions().ok()?;
     Some(dimensions)
+}
+
+// ── Direct-path variants (no world needed) ──
+
+fn read_map_db(map_path: &str) -> Result<Connection, UiError> {
+    let uri = format!("file:{}?immutable=1", map_path);
+    Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| UiError::from(format!("Map DB open error: {e}")))
+}
+
+fn find_map_table(conn: &Connection) -> Result<String, UiError> {
+    conn.query_row(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' LIMIT 1",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|e| UiError::from(format!("Table query error: {e}")))
+}
+
+#[command]
+pub fn get_map_bounds_by_path(map_path: String) -> Result<MapBounds, UiError> {
+    let conn = read_map_db(&map_path)?;
+    let table_name = find_map_table(&conn)?;
+
+    let tile_count: i64 = conn
+        .query_row(&format!("SELECT COUNT(*) FROM {}", table_name), [], |row| {
+            row.get(0)
+        })
+        .map_err(|e| UiError::from(format!("Count query error: {e}")))?;
+
+    let mut stmt = conn
+        .prepare(&format!("SELECT position FROM {}", table_name))
+        .map_err(|e| UiError::from(format!("Position query error: {e}")))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|e| UiError::from(format!("Position query error: {e}")))?;
+
+    let mut min_x = i32::MAX;
+    let mut max_x = i32::MIN;
+    let mut min_y = i32::MAX;
+    let mut max_y = i32::MIN;
+
+    while let Some(row) = rows.next().map_err(|e| UiError::from(format!("{e}")))? {
+        let position: i64 = row.get(0).map_err(|e| UiError::from(format!("{e}")))?;
+        let (x, y) = decode_position(position);
+        min_x = min_x.min(x);
+        max_x = max_x.max(x);
+        min_y = min_y.min(y);
+        max_y = max_y.max(y);
+    }
+
+    Ok(MapBounds {
+        min_x,
+        max_x,
+        min_y,
+        max_y,
+        tile_count,
+    })
+}
+
+#[command]
+pub fn get_all_map_tiles_by_path(map_path: String) -> Result<Vec<MapTile>, UiError> {
+    let conn = read_map_db(&map_path)?;
+    let table_name = find_map_table(&conn)?;
+
+    let mut stmt = conn
+        .prepare(&format!("SELECT position, data FROM {}", table_name))
+        .map_err(|e| UiError::from(format!("Tile query error: {e}")))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|e| UiError::from(format!("Tile query error: {e}")))?;
+
+    let mut tiles = Vec::new();
+    while let Some(row) = rows.next().map_err(|e| UiError::from(format!("{e}")))? {
+        let position: i64 = row.get(0).map_err(|e| UiError::from(format!("{e}")))?;
+        let data: Vec<u8> = row.get(1).map_err(|e| UiError::from(format!("{e}")))?;
+        let (x, y) = decode_position(position);
+        let (image_data, width, height) = if let Ok(map_piece) = MapPieceDb::decode(data.as_slice())
+        {
+            let pixel_count = map_piece.pixels.len();
+            let size = (pixel_count as f64).sqrt() as u32;
+            let png_data = pixels_to_png(&map_piece.pixels, size, size)?;
+            (png_data, size, size)
+        } else {
+            let (w, h) = detect_image_dimensions(&data).unwrap_or((512, 512));
+            (data, w, h)
+        };
+        tiles.push(MapTile {
+            x,
+            y,
+            position,
+            image_data,
+            width,
+            height,
+        });
+    }
+    Ok(tiles)
 }

--- a/src/components/dialogs/viewmap.dialog.tsx
+++ b/src/components/dialogs/viewmap.dialog.tsx
@@ -15,20 +15,27 @@ import type { World } from "@/lib/types";
 import { useDialogStore } from "@/stores/dialogs";
 
 export type ViewMapDialogProps = {
-  world: World;
+  world?: World;
+  mapPath?: string;
+  mapName?: string;
 };
 
 export function ViewMapDialog({
   open,
   world,
+  mapPath: directMapPath,
+  mapName,
 }: {
   open: boolean;
 } & ViewMapDialogProps) {
   const { closeDialog } = useDialogStore();
-  const worldData = world.data;
-  const worldPath = world.path;
-  const mapMarkers = world.map_markers;
-  const prospectingLogs = world.prospecting_logs;
+  const worldData = world?.data;
+  const worldPath = world?.path;
+  const mapMarkers = world?.map_markers;
+  const prospectingLogs = world?.prospecting_logs;
+
+  // Use direct map path if provided, otherwise derive from world
+  const displayName = mapName ?? worldData?.world_name ?? "Map";
   const players = useMemo(() => {
     const players: string[] = [];
     if (mapMarkers && prospectingLogs) {
@@ -63,7 +70,7 @@ export function ViewMapDialog({
         }}
       >
         <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
-          <DialogTitle>{worldData.world_name} - World Map</DialogTitle>
+          <DialogTitle>{displayName} - World Map</DialogTitle>
           <DialogDescription>
             Interactive map viewer • Drag to pan • Scroll to zoom
           </DialogDescription>
@@ -97,6 +104,7 @@ export function ViewMapDialog({
         <div className="min-h-0 w-full flex-1 overflow-hidden p-4">
           <WorldMapViewer
             mapMarkers={mapMarkers}
+            mapPath={directMapPath}
             prospectingLogs={prospectingLogs}
             selectedPlayer={selectedPlayer}
             showProspect={showProspect}

--- a/src/components/items/map.item.tsx
+++ b/src/components/items/map.item.tsx
@@ -1,0 +1,53 @@
+import { MapIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Group, GroupItem } from "@/components/ui/group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { MapEntry } from "@/hooks/use-world-map";
+import { useDialogStore } from "@/stores/dialogs";
+import { useInstallations } from "@/stores/installations";
+
+export function MapItem({ map }: { map: MapEntry }) {
+  const { installations } = useInstallations();
+  const { openDialog } = useDialogStore();
+  const installation = installations.find((inst) => inst.id === map.installation_id);
+
+  return (
+    <div className="grid w-full grid-cols-3 items-center justify-between">
+      <div className="flex flex-col">
+        <p className="text-sm">{map.name}</p>
+        <p className="text-muted-foreground text-xs">
+          {installation?.name ?? map.installation_name}
+        </p>
+      </div>
+      <div className="flex flex-col">
+        <p className="text-muted-foreground text-sm">Standalone map</p>
+        <p className="text-muted-foreground text-xs">No save attached</p>
+      </div>
+      <Group className="w-full justify-end">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <GroupItem
+                render={
+                  <Button
+                    onClick={() =>
+                      openDialog("ViewMapDialog", {
+                        mapPath: map.path,
+                        mapName: map.name,
+                      })
+                    }
+                    variant="outline"
+                  />
+                }
+              >
+                <MapIcon aria-hidden="true" className="-ms-1 text-blue-300 opacity-60" size={16} />
+              </GroupItem>
+            }
+          />
+          <TooltipContent>View Map</TooltipContent>
+        </Tooltip>
+      </Group>
+    </div>
+  );
+}

--- a/src/components/maps/world-map-viewer.tsx
+++ b/src/components/maps/world-map-viewer.tsx
@@ -2,7 +2,13 @@ import { ArrowDownToDotIcon, Loader2Icon, MapIcon, SparkleIcon } from "lucide-re
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Card } from "@/components/ui/card";
-import { imageDataToDataUrl, useAllMapTiles, useMapBounds } from "@/hooks/use-world-map";
+import {
+  imageDataToDataUrl,
+  useAllMapTiles,
+  useAllMapTilesByPath,
+  useMapBounds,
+  useMapBoundsByPath,
+} from "@/hooks/use-world-map";
 import type {
   MapMarker,
   MapMarkers,
@@ -13,7 +19,8 @@ import type {
 import { cn } from "@/lib/utils";
 
 type WorldMapViewerProps = {
-  worldPath: string;
+  worldPath?: string;
+  mapPath?: string;
   mapMarkers?: MapMarkers | null | undefined;
   prospectingLogs?: [string, ProspectingLog][];
   selectedPlayer: string | null;
@@ -22,18 +29,28 @@ type WorldMapViewerProps = {
 
 export function WorldMapViewer({
   worldPath,
+  mapPath,
   mapMarkers,
   prospectingLogs,
   selectedPlayer,
   showProspect,
 }: WorldMapViewerProps) {
+  // Use direct path if provided, otherwise world path
+  const effectivePath = mapPath ?? worldPath ?? "";
+  const isDirectPath = !!mapPath;
   // Base (tiles) and overlay (markers, cursor) canvases
   const baseCanvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { data: tiles, isLoading: tilesLoading, error: tilesError } = useAllMapTiles(worldPath);
-  const { data: bounds, isLoading: boundsLoading } = useMapBounds(worldPath);
+  const {
+    data: tiles,
+    isLoading: tilesLoading,
+    error: tilesError,
+  } = isDirectPath ? useAllMapTilesByPath(effectivePath) : useAllMapTiles(effectivePath);
+  const { data: bounds, isLoading: boundsLoading } = isDirectPath
+    ? useMapBoundsByPath(effectivePath)
+    : useMapBounds(effectivePath);
 
   // Viewport state (x, y = top-left corner in world coords, zoom = scale factor)
   const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 0.5 });

--- a/src/hooks/use-world-map.ts
+++ b/src/hooks/use-world-map.ts
@@ -3,7 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 
 import type { MapBounds, MapDatabaseInfo, MapTile } from "@/lib/types";
 
-// Query key factories
+// ── Query key factories ──
+
 export const worldMapKeys = {
   all: ["world-map"] as const,
   allTiles: (worldPath: string) => [...worldMapKeys.all, "tiles", worldPath] as const,
@@ -13,10 +14,8 @@ export const worldMapKeys = {
     [...worldMapKeys.all, "tile", worldPath, position] as const,
 };
 
-/**
- * Hook to inspect the Maps database for a world
- * Returns schema information, table count, and sample positions
- */
+// ── World-based hooks (existing) ──
+
 export const useMapDatabaseInspection = (
   worldPath: string,
   options?: Omit<UseQueryOptions<MapDatabaseInfo, Error, MapDatabaseInfo>, "queryKey" | "queryFn">,
@@ -28,10 +27,6 @@ export const useMapDatabaseInspection = (
     ...options,
   });
 
-/**
- * Hook to get the bounds (min/max X,Y) of the map
- * Useful for setting up the initial viewport
- */
 export const useMapBounds = (
   worldPath: string,
   options?: Omit<UseQueryOptions<MapBounds, Error, MapBounds>, "queryKey" | "queryFn">,
@@ -43,10 +38,6 @@ export const useMapBounds = (
     ...options,
   });
 
-/**
- * Hook to get a single map tile by position
- * Useful for testing or lazy loading individual tiles
- */
 export const useMapTile = (
   worldPath: string,
   position: number,
@@ -59,10 +50,6 @@ export const useMapTile = (
     ...options,
   });
 
-/**
- * Hook to get all map tiles for a world
- * Use with caution for large maps - consider pagination or lazy loading
- */
 export const useAllMapTiles = (
   worldPath: string,
   options?: Omit<UseQueryOptions<MapTile[], Error, MapTile[]>, "queryKey" | "queryFn">,
@@ -71,13 +58,93 @@ export const useAllMapTiles = (
     enabled: !!worldPath,
     queryFn: () => invoke<MapTile[]>("get_all_map_tiles", { worldPath }),
     queryKey: worldMapKeys.allTiles(worldPath),
-    staleTime: 1000 * 60 * 5, // Cache for 5 minutes
+    staleTime: 1000 * 60 * 5,
     ...options,
   });
 
-/**
- * Utility function to convert image_data array to a data URL
- */
+// ── Map listing (all installations) ──
+
+export type MapEntry = {
+  id: number;
+  name: string;
+  installation_id: number;
+  installation_name: string;
+  path: string;
+  size_bytes: number;
+};
+
+const allMapsKeys = ["all-maps"] as const;
+
+export const useAllMaps = (
+  options?: Omit<UseQueryOptions<MapEntry[], Error, MapEntry[]>, "queryKey" | "queryFn">,
+) =>
+  useQuery({
+    queryFn: () => invoke<MapEntry[]>("get_all_maps"),
+    queryKey: allMapsKeys,
+    staleTime: 1000 * 60 * 2,
+    ...options,
+  });
+
+// ── Direct-path variants (no world needed) ──
+
+const dirMapKeys = {
+  bounds: (mapPath: string) => ["map-bounds-direct", mapPath] as const,
+  tiles: (mapPath: string) => ["map-tiles-direct", mapPath] as const,
+};
+
+export const useMapBoundsByPath = (
+  mapPath: string,
+  options?: Omit<UseQueryOptions<MapBounds, Error, MapBounds>, "queryKey" | "queryFn">,
+) =>
+  useQuery({
+    enabled: !!mapPath,
+    queryFn: () => invoke<MapBounds>("get_map_bounds_by_path", { mapPath }),
+    queryKey: dirMapKeys.bounds(mapPath),
+    ...options,
+  });
+
+export const useAllMapTilesByPath = (
+  mapPath: string,
+  options?: Omit<UseQueryOptions<MapTile[], Error, MapTile[]>, "queryKey" | "queryFn">,
+) =>
+  useQuery({
+    enabled: !!mapPath,
+    queryFn: () => invoke<MapTile[]>("get_all_map_tiles_by_path", { mapPath }),
+    queryKey: dirMapKeys.tiles(mapPath),
+    staleTime: 1000 * 60 * 5,
+    ...options,
+  });
+
+// ── Map favorites (localStorage-backed) ──
+
+const FAV_KEY = "storyforge-map-favorites";
+
+export function getFavoriteMaps(): Set<number> {
+  try {
+    const raw = localStorage.getItem(FAV_KEY);
+    return raw ? new Set(JSON.parse(raw)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveFavoriteMaps(favorites: Set<number>) {
+  localStorage.setItem(FAV_KEY, JSON.stringify([...favorites]));
+}
+
+export function toggleFavoriteMap(mapId: number) {
+  const favs = getFavoriteMaps();
+  if (favs.has(mapId)) {
+    favs.delete(mapId);
+  } else {
+    favs.add(mapId);
+  }
+  saveFavoriteMaps(favs);
+  return favs;
+}
+
+// ── Utilities ──
+
 export function imageDataToDataUrl(imageData: number[]): string {
   const bytes = new Uint8Array(imageData);
   let binary = "";
@@ -88,9 +155,6 @@ export function imageDataToDataUrl(imageData: number[]): string {
   return `data:image/png;base64,${base64}`;
 }
 
-/**
- * Utility function to create an Image element from map tile data
- */
 export function createImageFromTile(tile: MapTile): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();

--- a/src/routes/worlds.tsx
+++ b/src/routes/worlds.tsx
@@ -2,10 +2,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { SearchInput } from "@/components/inputs";
+import { MapItem } from "@/components/items/map.item";
 import { WorldList } from "@/components/lists/world.list";
 import { ErrorComponent } from "@/components/ui/error";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 import { useSaves } from "@/hooks/use-saves";
+import { useAllMaps } from "@/hooks/use-world-map";
 import { cn } from "@/lib/utils";
 import { useInstallations } from "@/stores/installations";
 
@@ -15,15 +17,22 @@ export const Route = createFileRoute("/worlds")({
 });
 
 function RouteComponent() {
-  // States
   const [searchText, setSearchText] = useState("");
   const [selectedInstallationId, setSelectedInstallationId] = useState<number | null>(null);
 
-  // Stores
   const { installations } = useInstallations();
 
-  // Queries
   const { data: worlds } = useSaves();
+  const { data: allMaps } = useAllMaps();
+
+  // Standalone maps: maps not already attached to a world save
+  const standaloneMaps = (allMaps ?? []).filter(
+    (map) =>
+      !(worlds ?? []).some(
+        (w) => w.has_map && w.data.savegame_identifier && map.name === w.data.savegame_identifier,
+      ),
+  );
+
   const filteredWorlds = worlds?.filter((world) => {
     const matchesSearchText = world.data.world_name
       .toLowerCase()
@@ -36,12 +45,20 @@ function RouteComponent() {
     return matchesSearchText && matchesInstallation;
   });
 
+  const filteredMaps = standaloneMaps.filter((map) => {
+    const matchesSearchText = map.name.toLowerCase().includes(searchText.toLowerCase());
+    const matchesInstallation = selectedInstallationId
+      ? map.installation_id === selectedInstallationId
+      : true;
+    return matchesSearchText && matchesInstallation;
+  });
+
   return (
     <div className="grid w-full grid-rows-[min-content_1fr] gap-2" style={{ height: "100vh" }}>
       <div className="bg-background/10 sticky top-0 z-10 flex h-fit flex-wrap items-center gap-2 px-4 py-2 backdrop-blur-md">
         <SearchInput
           onChange={(e) => setSearchText(e.target.value)}
-          placeholder="Search worlds..."
+          placeholder="Search worlds and maps..."
           value={searchText}
         />
         <Select value={selectedInstallationId?.toString() || ""}>
@@ -72,6 +89,20 @@ function RouteComponent() {
       {filteredWorlds && (
         <div className="relative h-full w-full overflow-auto px-4">
           <WorldList worlds={filteredWorlds} />
+          {filteredMaps.length > 0 && (
+            <div className="mt-4">
+              <p className="text-muted-foreground px-2 py-1 text-xs font-semibold tracking-wider uppercase">
+                Maps without saves
+              </p>
+              <div className="bg-card relative flex w-full flex-col overflow-y-auto rounded border p-2 shadow">
+                {filteredMaps.map((map) => (
+                  <div key={`map-${map.id}`} className="flex w-full gap-2 p-2 not-last:border-b">
+                    <MapItem map={map} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Add ability to view Maps databases directly without requiring an attached save file. Includes:
- New commands to read map data directly from path
- UI components to display standalone maps
- Integration with existing map viewer
- Support for scanning all installations for Maps databases

## Summary

- Briefly describe the purpose of this PR.
- What problem does it solve or what feature does it add?

## Changes

- List the key changes in this PR.
- Include noteworthy implementation details or trade-offs.

## Related Issues

- Closes #<number>
- Fixes #<number>
- Resolves #<number>
  (Use keywords so merging will auto-close the issues. Example: Closes #23)

## Screenshots / Demos (if applicable)

- Add before/after screenshots, recordings, or GIFs.
- Include instructions to reproduce any UI changes.

## Checklist

- [ ] I have linked related issues using #<number>
- [ ] I have updated documentation where appropriate
- [ ] I have verified backward compatibility or noted breaking changes
- [ ] I have run linters/formatters and addressed warnings

## Breaking Changes (if any)

- Describe any breaking changes and migration steps.

## Additional Context

- Anything else reviewers should know (decisions, trade-offs, follow-ups).

## Reviewers

- @tag-relevant-reviewer-1
  (Please tag code owners, domain experts, and stakeholders.)
