### PR TITLE
feat: add server sniffer module

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 mod modules;
-use modules::{auth, download, installations, maps, mods, news, saves, servers, versions};
+use modules::{auth, download, installations, maps, mods, news, saves, servers, sniffer, versions};
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -70,6 +70,8 @@ pub fn run() {
             // Servers
             servers::fetch_public_servers,
             servers::fetch_all_servers,
+            // Sniffer
+            sniffer::sniff_server,
             servers::add_server_to_installation,
             servers::remove_server_from_installation,
             servers::check_server_in_installation,

--- a/src-tauri/src/modules.rs
+++ b/src-tauri/src/modules.rs
@@ -9,5 +9,6 @@ pub mod news;
 pub mod proto;
 pub mod saves;
 pub mod servers;
+pub mod sniffer;
 pub mod utils;
 pub mod versions;

--- a/src-tauri/src/modules/sniffer.rs
+++ b/src-tauri/src/modules/sniffer.rs
@@ -1,0 +1,438 @@
+use serde::Serialize;
+use std::{
+    io::{Read, Write},
+    net::{SocketAddr, TcpStream, ToSocketAddrs},
+    time::Duration,
+};
+
+use super::errors::UiError;
+
+// ── Varint ──
+
+fn write_varint(value: u64) -> Vec<u8> {
+    let mut result = Vec::new();
+    let mut v = value;
+    loop {
+        let mut byte = (v & 0x7F) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        result.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+    result
+}
+
+fn read_varint(data: &[u8], offset: &mut usize) -> Option<u64> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    while *offset < data.len() {
+        let byte = data[*offset];
+        *offset += 1;
+        value |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Some(value);
+        }
+        shift += 7;
+    }
+    None
+}
+
+// ── Wire helpers ──
+
+fn wire_string(tag: u64, value: &str) -> Vec<u8> {
+    let encoded = value.as_bytes();
+    let mut buf = write_varint((tag << 3) | 2);
+    buf.extend(write_varint(encoded.len() as u64));
+    buf.extend(encoded);
+    buf
+}
+
+fn wire_varint(tag: u64, value: u64) -> Vec<u8> {
+    let mut buf = write_varint((tag << 3) | 0);
+    buf.extend(write_varint(value));
+    buf
+}
+
+fn wire_message(tag: u64, message: &[u8]) -> Vec<u8> {
+    let mut buf = write_varint((tag << 3) | 2);
+    buf.extend(write_varint(message.len() as u64));
+    buf.extend(message);
+    buf
+}
+
+// ── Packet builders ──
+
+fn build_client_identification(
+    game_version: &str,
+    player_name: &str,
+    server_password: &str,
+    player_uid: &str,
+    view_distance: u64,
+    network_version: &str,
+) -> Vec<u8> {
+    let mut msg = Vec::new();
+    msg.extend(wire_string(1, game_version));
+    msg.extend(wire_string(2, player_name));
+    if !server_password.is_empty() {
+        msg.extend(wire_string(4, server_password));
+    }
+    msg.extend(wire_string(6, player_uid));
+    msg.extend(wire_varint(7, view_distance));
+    msg.extend(wire_string(9, network_version));
+    msg.extend(wire_string(10, game_version));
+    msg
+}
+
+fn build_packet_client(identification: &[u8]) -> Vec<u8> {
+    wire_message(2, identification)
+}
+
+fn build_wire_packet(payload: &[u8]) -> Vec<u8> {
+    let len = payload.len() as u32;
+    let mut buf = len.to_be_bytes().to_vec();
+    buf.extend(payload);
+    buf
+}
+
+// ── Network I/O ──
+
+fn send_packet(addr: &SocketAddr, wire: &[u8], timeout: Duration) -> Result<Vec<u8>, UiError> {
+    let mut stream = TcpStream::connect_timeout(addr, timeout).map_err(|e| UiError {
+        name: "connect_failed".into(),
+        message: format!("Failed to connect to {}: {e}", addr),
+    })?;
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|e| UiError {
+            name: "timeout_error".into(),
+            message: format!("Failed to set write timeout: {e}"),
+        })?;
+
+    stream.write_all(wire).map_err(|e| UiError {
+        name: "send_failed".into(),
+        message: format!("Failed to send packet: {e}"),
+    })?;
+
+    let mut data = Vec::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(e) => {
+                return Err(UiError {
+                    name: "recv_failed".into(),
+                    message: format!("Failed to read response: {e}"),
+                });
+            }
+        }
+    }
+    Ok(data)
+}
+
+// ── Protobuf parser ──
+
+fn parse_protobuf(payload: &[u8]) -> serde_json::Value {
+    let mut result = serde_json::Map::new();
+    let mut offset: usize = 0;
+
+    while offset < payload.len() {
+        let wire_tag = match read_varint(payload, &mut offset) {
+            Some(v) => v,
+            None => break,
+        };
+        let tag = wire_tag >> 3;
+        let wire_type = wire_tag & 0x07;
+
+        match wire_type {
+            0 => {
+                if let Some(val) = read_varint(payload, &mut offset) {
+                    result.insert(format!("int_{tag}"), serde_json::Value::Number(val.into()));
+                } else {
+                    break;
+                }
+            }
+            2 => {
+                let length = match read_varint(payload, &mut offset) {
+                    Some(v) => v as usize,
+                    None => break,
+                };
+                if offset + length > payload.len() {
+                    break;
+                }
+                let raw = &payload[offset..offset + length];
+                offset += length;
+
+                if let Ok(s) = std::str::from_utf8(raw) {
+                    result.insert(
+                        format!("str_{tag}"),
+                        serde_json::Value::String(s.to_string()),
+                    );
+                } else {
+                    let nested = parse_protobuf(raw);
+                    if nested.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+                        result.insert(
+                            format!("hex_{tag}"),
+                            serde_json::Value::String(bytes_to_hex(raw)),
+                        );
+                    } else {
+                        result.insert(format!("msg_{tag}"), nested);
+                    }
+                }
+            }
+            _ => break,
+        }
+    }
+
+    serde_json::Value::Object(result)
+}
+
+fn parse_response_packets(data: &[u8]) -> Vec<serde_json::Value> {
+    let mut packets = Vec::new();
+    let mut offset: usize = 0;
+
+    while offset + 4 <= data.len() {
+        let pkt_len = u32::from_be_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+
+        if pkt_len == 0 || offset + 4 + pkt_len > data.len() {
+            break;
+        }
+
+        let payload = &data[offset + 4..offset + 4 + pkt_len];
+        packets.push(parse_protobuf(payload));
+        offset += 4 + pkt_len;
+    }
+
+    packets
+}
+
+fn extract_strings_recursive(value: &serde_json::Value) -> Vec<String> {
+    let mut strings = Vec::new();
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                if k.starts_with("str_") {
+                    if let Some(s) = v.as_str() {
+                        strings.push(s.to_string());
+                    }
+                } else {
+                    strings.extend(extract_strings_recursive(v));
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                strings.extend(extract_strings_recursive(v));
+            }
+        }
+        _ => {}
+    }
+    strings
+}
+
+fn extract_version(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'v' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && (bytes[end].is_ascii_digit() || bytes[end] == b'.') {
+                end += 1;
+            }
+            if end > start {
+                return Some(text[start..end].to_string());
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn extract_server_info(packets: &[serde_json::Value]) -> ServerSniffResult {
+    let mut info = ServerSniffResult::default();
+
+    let all_strings: Vec<String> = packets.iter().flat_map(extract_strings_recursive).collect();
+    let full_text = all_strings.join("");
+
+    // Version from disconnect message: "Server: v1.22.2 (nv: 1.22.2)"
+    if let Some(start) = full_text.find("Server:") {
+        let after = &full_text[start..];
+        if let Some(ver) = extract_version(after) {
+            info.server_game_version = Some(ver);
+        }
+        if let Some(nv_start) = after.find("(nv:") {
+            let nv_after = &after[nv_start + 4..];
+            let nv: String = nv_after
+                .chars()
+                .skip_while(|c| !c.is_ascii_digit())
+                .take_while(|c| c.is_ascii_digit() || *c == '.')
+                .collect();
+            if !nv.is_empty() {
+                info.server_network_version = Some(nv);
+            }
+        }
+    }
+
+    let lower = full_text.to_lowercase();
+    // Print debug info
+    info.password_protected = lower.contains("password") || lower.contains("enter password");
+    info.whitelisted = lower.contains("whitelist");
+    info.banned = lower.contains("banned");
+    info.server_full = lower.contains("queue") || lower.contains("full");
+    info.auth_required = lower.contains("bad game session");
+    // password_valid set by sniff_server step 3
+
+    for p in packets {
+        if let Some(token) = p.get("str_2").and_then(|v| v.as_str()) {
+            info.login_token = Some(token.to_string());
+        }
+    }
+
+    let clean = full_text.trim().to_string();
+    info.disconnect_message = if clean.is_empty() { None } else { Some(clean) };
+
+    info
+}
+
+// ── Helpers ──
+
+fn bytes_to_hex(data: &[u8]) -> String {
+    data.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+// ── Result type ──
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ServerSniffResult {
+    pub server_game_version: Option<String>,
+    pub server_network_version: Option<String>,
+    pub password_protected: bool,
+    pub password_valid: Option<bool>,
+    pub whitelisted: bool,
+    pub banned: bool,
+    pub server_full: bool,
+    pub auth_required: bool,
+    pub login_token: Option<String>,
+    pub disconnect_message: Option<String>,
+}
+
+// ── Command ──
+
+/// Probes a Vintage Story server to detect version, password status, etc.
+///
+/// Two-step process:
+/// 1. Send wrong version → get server's real version + basic flags
+/// 2. Send correct version + password → get detailed auth/password/whitelist status
+#[tauri::command]
+pub fn sniff_server(
+    host: String,
+    port: Option<u16>,
+    password: Option<String>,
+    timeout_secs: Option<f64>,
+) -> Result<ServerSniffResult, UiError> {
+    let port = port.unwrap_or(42420);
+    let timeout = Duration::from_secs_f64(timeout_secs.unwrap_or(8.0));
+    let password = password.unwrap_or_default();
+
+    let host_port = format!("{host}:{port}");
+    let addr = host_port
+        .to_socket_addrs()
+        .map_err(|e| UiError {
+            name: "invalid_address".into(),
+            message: format!("Failed to resolve {host}:{port} - {e}"),
+        })?
+        .next()
+        .ok_or_else(|| UiError {
+            name: "invalid_address".into(),
+            message: format!("Could not resolve {host}:{port}"),
+        })?;
+
+    // ── Step 1: probe with wrong version ──
+    let ident1 = build_client_identification(
+        "1.99.99",
+        "ServerSniffer",
+        "", // no password on first probe
+        "sniffer",
+        128,
+        "999.99.99",
+    );
+    let data1 = send_packet(
+        &addr,
+        &build_wire_packet(&build_packet_client(&ident1)),
+        timeout,
+    )?;
+    let packets1 = parse_response_packets(&data1);
+    let mut info = extract_server_info(&packets1);
+
+    // ── Step 2: probe with correct version, NO password (detects password/whitelist) ──
+    if let (Some(ver), Some(nver)) = (&info.server_game_version, &info.server_network_version) {
+        let ident2 = build_client_identification(
+            ver,
+            "ServerSniffer",
+            "", // no password — server will tell us if one is needed
+            "sniffer",
+            128,
+            nver,
+        );
+        if let Ok(data2) = send_packet(
+            &addr,
+            &build_wire_packet(&build_packet_client(&ident2)),
+            timeout,
+        ) {
+            let info2 = extract_server_info(&parse_response_packets(&data2));
+            info.password_protected = info.password_protected || info2.password_protected;
+            info.whitelisted = info.whitelisted || info2.whitelisted;
+            info.banned = info.banned || info2.banned;
+            info.server_full = info.server_full || info2.server_full;
+        }
+
+        // ── Step 3: if user provided a password, test it ──
+        if !password.is_empty() {
+            let ident3 =
+                build_client_identification(ver, "ServerSniffer", &password, "sniffer", 128, nver);
+            if let Ok(data3) = send_packet(
+                &addr,
+                &build_wire_packet(&build_packet_client(&ident3)),
+                timeout,
+            ) {
+                let info3 = extract_server_info(&parse_response_packets(&data3));
+                // If server says "bad game session", password was accepted
+                // If server still says "password", the password was wrong
+                let lower3 = info3
+                    .disconnect_message
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_lowercase();
+                info.auth_required = info3.auth_required || lower3.contains("bad game session");
+                info.password_valid = if info.auth_required {
+                    Some(true)
+                } else if lower3.contains("password") || info3.password_protected {
+                    Some(false) // server still asking for password → wrong
+                } else {
+                    None
+                };
+                if info3.login_token.is_some() {
+                    info.login_token = info3.login_token;
+                }
+                if info3.disconnect_message.is_some() {
+                    info.disconnect_message = info3.disconnect_message;
+                }
+            }
+        }
+    }
+
+    Ok(info)
+}

--- a/src/components/dialogs/addserver.dialog.tsx
+++ b/src/components/dialogs/addserver.dialog.tsx
@@ -1,6 +1,9 @@
 import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
 import clsx from "clsx";
-import { useId } from "react";
+import { Loader2Icon } from "lucide-react";
+import { useState, useId } from "react";
 import { toast } from "sonner";
 import z from "zod";
 
@@ -22,6 +25,19 @@ import { useAddServerToInstallation } from "@/hooks/use-add-server-to-installati
 import { useDialogStore } from "@/stores/dialogs";
 import { type Installation, useInstallations } from "@/stores/installations";
 import { useServerStore } from "@/stores/servers";
+
+type SniffResult = {
+  server_game_version: string | null;
+  server_network_version: string | null;
+  password_protected: boolean;
+  password_valid: boolean | null;
+  whitelisted: boolean;
+  banned: boolean;
+  server_full: boolean;
+  auth_required: boolean;
+  login_token: string | null;
+  disconnect_message: string | null;
+};
 
 export const serverSchema = z.object({
   favorite: z.boolean(),
@@ -53,6 +69,26 @@ export function AddServerDialog({ open, installation }: { open: boolean } & AddS
   const { installations } = useInstallations();
   const { addServer, loadServers } = useServerStore();
   const { mutateAsync, isPending } = useAddServerToInstallation();
+  const [sniffResult, setSniffResult] = useState<SniffResult | null>(null);
+  const { mutate: testServer, isPending: isTesting } = useMutation({
+    mutationFn: async () => {
+      const ip = form.getFieldValue("ip");
+      const portStr = form.getFieldValue("port");
+      const password = form.getFieldValue("password");
+      return invoke<SniffResult>("sniff_server", {
+        host: ip,
+        password: password || undefined,
+        port: portStr ? Number.parseInt(portStr, 10) : undefined,
+      });
+    },
+    onError: (error) => {
+      toast.error(`Failed to test server: ${error.message}`);
+      setSniffResult(null);
+    },
+    onSuccess: (data) => {
+      setSniffResult(data);
+    },
+  });
   const form = useForm({
     defaultValues: {
       favorite: false,
@@ -376,9 +412,71 @@ export function AddServerDialog({ open, installation }: { open: boolean } & AddS
               )}
             </form.Field>
           </div>
-          <Button className="w-full" onClick={() => form.handleSubmit()} type="button">
-            Add Server
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              className="flex-1"
+              disabled={isTesting}
+              onClick={() => testServer()}
+              type="button"
+              variant="outline"
+            >
+              {isTesting ? (
+                <>
+                  <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                  Testing...
+                </>
+              ) : (
+                "Test Server"
+              )}
+            </Button>
+            <Button className="flex-1" onClick={() => form.handleSubmit()} type="button">
+              Add Server
+            </Button>
+          </div>
+          {sniffResult && (
+            <div className="bg-muted flex flex-col space-y-1 rounded border p-3 text-xs">
+              {sniffResult.server_game_version && (
+                <p>
+                  <span className="text-muted-foreground">Server version:</span>{" "}
+                  <span className="font-mono">v{sniffResult.server_game_version}</span>
+                  {(() => {
+                    const instId = form.getFieldValue("installationId");
+                    const inst = installations.find((i) => i.id.toString() === instId);
+                    if (inst && sniffResult.server_game_version) {
+                      const match = inst.version === sniffResult.server_game_version;
+                      return (
+                        <span className={match ? "text-success ml-1" : "text-destructive ml-1"}>
+                          {match
+                            ? "✓ matches your installation"
+                            : "✗ differs from your installation"}
+                        </span>
+                      );
+                    }
+                    return null;
+                  })()}
+                </p>
+              )}
+              {sniffResult.password_protected && (
+                <p>
+                  <span className="text-muted-foreground">Password:</span>{" "}
+                  {sniffResult.password_valid === true ? (
+                    <span className="text-success">Correct</span>
+                  ) : sniffResult.password_valid === false ? (
+                    <span className="text-destructive">Incorrect</span>
+                  ) : (
+                    <span className="text-warning-foreground">
+                      Required (enter password to test)
+                    </span>
+                  )}
+                </p>
+              )}
+              {sniffResult.whitelisted && (
+                <p className="text-warning-foreground">Server is whitelisted</p>
+              )}
+              {sniffResult.server_full && <p className="text-destructive">Server is full</p>}
+              {sniffResult.banned && <p className="text-destructive">You are banned</p>}
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/dialogs/addserver.dialog.tsx
+++ b/src/components/dialogs/addserver.dialog.tsx
@@ -98,7 +98,7 @@ export function AddServerDialog({ open, installation }: { open: boolean } & AddS
       ip: "",
       name: "",
       password: "",
-      port: null as string | null,
+      port: "42420",
     },
     onSubmit: async ({ value }) => {
       await mutateAsync(

--- a/src/components/dialogs/editserver.dialog.tsx
+++ b/src/components/dialogs/editserver.dialog.tsx
@@ -1,8 +1,23 @@
 import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import clsx from "clsx";
-import { useId } from "react";
+import { Loader2Icon } from "lucide-react";
+import { useState, useId } from "react";
+import { toast } from "sonner";
 
+type SniffResult = {
+  server_game_version: string | null;
+  server_network_version: string | null;
+  password_protected: boolean;
+  password_valid: boolean | null;
+  whitelisted: boolean;
+  banned: boolean;
+  server_full: boolean;
+  auth_required: boolean;
+  login_token: string | null;
+  disconnect_message: string | null;
+};
 import { serverSchema } from "@/components/dialogs/addserver.dialog";
 import { PasswordInput } from "@/components/inputs";
 import { Button } from "@/components/ui/button";
@@ -36,6 +51,26 @@ export function EditServerDialog({
   const { closeDialog } = useDialogStore();
   const { installations } = useInstallations();
   const { updateServer, loadServers } = useServerStore();
+  const [sniffResult, setSniffResult] = useState<SniffResult | null>(null);
+  const { mutate: testServer, isPending: isTesting } = useMutation({
+    mutationFn: async () => {
+      const ip = form.getFieldValue("ip");
+      const portStr = form.getFieldValue("port");
+      const password = form.getFieldValue("password");
+      return invoke<SniffResult>("sniff_server", {
+        host: ip,
+        password: password || undefined,
+        port: portStr ? Number.parseInt(portStr, 10) : undefined,
+      });
+    },
+    onError: (error) => {
+      toast.error(`Failed to test server: ${error.message}`);
+      setSniffResult(null);
+    },
+    onSuccess: (data) => {
+      setSniffResult(data);
+    },
+  });
   const form = useForm({
     defaultValues: {
       favorite: server.favorite,
@@ -191,10 +226,10 @@ export function EditServerDialog({
                 </div>
               )}
             </form.Field>
-            <div className="flex gap-2">
+            <div className="grid grid-cols-2 gap-2">
               <form.Field name="ip">
                 {(field) => (
-                  <div className="grid gap-2">
+                  <div className="grid w-full gap-2">
                     <Tooltip>
                       <TooltipTrigger
                         render={
@@ -240,7 +275,7 @@ export function EditServerDialog({
               </form.Field>
               <form.Field name="port">
                 {(field) => (
-                  <div className="grid gap-2">
+                  <div className="grid w-full gap-2">
                     <Tooltip>
                       <TooltipTrigger
                         render={
@@ -340,9 +375,74 @@ export function EditServerDialog({
               )}
             </form.Field>
           </div>
-          <Button className="w-full" onClick={() => form.handleSubmit()} type="button">
-            Update Server
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              className="flex-1"
+              disabled={isTesting}
+              onClick={() => testServer()}
+              type="button"
+              variant="outline"
+            >
+              {isTesting ? (
+                <>
+                  <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                  Testing...
+                </>
+              ) : (
+                "Test Server"
+              )}
+            </Button>
+            <Button className="flex-1" onClick={() => form.handleSubmit()} type="button">
+              Update Server
+            </Button>
+          </div>
+          {sniffResult && (
+            <div className="bg-muted space-y-1 rounded border p-3 text-xs">
+              {sniffResult.server_game_version && (
+                <p>
+                  <span className="text-muted-foreground">Version:</span>{" "}
+                  <span className="font-mono">v{sniffResult.server_game_version}</span>
+                  {(() => {
+                    const instId = form.getFieldValue("installationId");
+                    const inst = installations.find((i) => i.id.toString() === instId);
+                    if (inst && sniffResult.server_game_version) {
+                      const match = inst.version === sniffResult.server_game_version;
+                      return (
+                        <span className={match ? "text-success ml-1" : "text-destructive ml-1"}>
+                          {match
+                            ? "✓ matches your installation"
+                            : "✗ differs from your installation"}
+                        </span>
+                      );
+                    }
+                    return null;
+                  })()}
+                </p>
+              )}
+              {sniffResult.password_protected && (
+                <p>
+                  <span className="text-muted-foreground">Password:</span>{" "}
+                  {sniffResult.password_valid === true ? (
+                    <span className="text-success">Correct</span>
+                  ) : sniffResult.password_valid === false ? (
+                    <span className="text-destructive">Incorrect</span>
+                  ) : (
+                    <span className="text-warning-foreground">
+                      Required (enter password to test)
+                    </span>
+                  )}
+                </p>
+              )}
+              {sniffResult.whitelisted && (
+                <p className="text-warning-foreground">Server is whitelisted</p>
+              )}
+              {sniffResult.server_full && <p className="text-destructive">Server is full</p>}
+              {sniffResult.banned && <p className="text-destructive">You are banned</p>}
+              {sniffResult.disconnect_message && (
+                <p className="text-muted-foreground truncate">{sniffResult.disconnect_message}</p>
+              )}
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Adds a new module to probe Vintage Story servers for:
- Game/network version
- Password protection status
- Whitelist/banned status
- Server full status
- Authentication requirements
- Login token
- Disconnect messages

Also updates UI to include server testing functionality in both add and edit dialogs

## Summary

- Briefly describe the purpose of this PR.
- What problem does it solve or what feature does it add?

## Changes

- List the key changes in this PR.
- Include noteworthy implementation details or trade-offs.

## Related Issues

- Closes #<number>
- Fixes #<number>
- Resolves #<number>
  (Use keywords so merging will auto-close the issues. Example: Closes #23)

## Screenshots / Demos (if applicable)

- Add before/after screenshots, recordings, or GIFs.
- Include instructions to reproduce any UI changes.

## Checklist

- [ ] I have linked related issues using #<number>
- [ ] I have updated documentation where appropriate
- [ ] I have verified backward compatibility or noted breaking changes
- [ ] I have run linters/formatters and addressed warnings

## Breaking Changes (if any)

- Describe any breaking changes and migration steps.

## Additional Context

- Anything else reviewers should know (decisions, trade-offs, follow-ups).

## Reviewers

- @tag-relevant-reviewer-1
  (Please tag code owners, domain experts, and stakeholders.)
