### PR TITLE
fix(servers): unregistered launch/dotnet listeners after terminal state

### DIFF
--- a/src/hooks/use-connect-to-server.ts
+++ b/src/hooks/use-connect-to-server.ts
@@ -65,6 +65,11 @@ export const useConnectToServer = (
       toast.error(`Error connecting to server: ${error.message}`);
     },
     onMutate: async (variable) => {
+      for (const unlisten of unlistens.current) {
+        unlisten();
+      }
+      unlistens.current = [];
+
       const installation = findInstallationForServer(installations, variable.installationId);
 
       // Listen for dotnet download progress
@@ -110,6 +115,13 @@ export const useConnectToServer = (
           toast.error(`Error launching game: ${event.payload.reason}`, {
             id: `launch-game-${variable.installationId}`,
           });
+        }
+        if (status === "success" || status === "error") {
+          unlistenDotnet();
+          unlistenLaunch();
+          unlistens.current = unlistens.current.filter(
+            (fn) => fn !== unlistenDotnet && fn !== unlistenLaunch,
+          );
         }
       });
       unlistens.current.push(unlistenLaunch);


### PR DESCRIPTION
## Summary

Fixes a UI bug where the "connect to server" toast could show the wrong server name after connecting to multiple servers that share the same game installation.

## Changes

- `useConnectToServer`'s `onMutate` registers Tauri event listeners (`launch-${installationId}`, `dotnet-download-${installationId}`) scoped by *installation*, not by server. Since multiple servers can share one installation, listeners from a previous connect attempt were never being unregistered, so their closures (holding the old server's name) kept firing on later connect attempts to a different server using the same installation — causing the success toast to display a stale server name even though the actual connection succeeded correctly.
- `onMutate` now clears out any listeners left over from a previous attempt before registering new ones (handles the case where a prior attempt never reached success/error).
- The `launch-` listener now unregisters itself (and its paired `dotnet-download-` listener) as soon as it reaches a terminal state (`success` or `error`), instead of living for the rest of the app's lifetime.

## Related Issues

N/A — found and reproduced this directly while testing the "connect to server" flow, not filed as an issue beforehand.

## Screenshots / Demos (if applicable)

N/A — internal event-listener/state-management fix, no visual or UI changes.

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — no breaking changes; purely internal to the hook
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint` pass clean

## Breaking Changes (if any)

None.

## Additional Context

Repro: connect to one server, then connect to a second server that uses the *same* installation — the success toast for the second connection could show the first server's name. The `play_game` invocation itself was always correct (right IP/installation), so gameplay wasn't affected — this was purely a stale-toast display bug.

## Reviewers

@LovelessCodes 