### PR TITLE
feat(servers): show live online/offline status on the Home screen

### DIFF
--- a/src-tauri/src/modules/sniffer.rs
+++ b/src-tauri/src/modules/sniffer.rs
@@ -340,13 +340,31 @@ pub struct ServerSniffResult {
 
 // ── Command ──
 
+/// Delegates to `sniff_server_blocking` via `spawn_blocking` so the probe can't block the UI thread.
+#[tauri::command]
+pub async fn sniff_server(
+    host: String,
+    port: Option<u16>,
+    password: Option<String>,
+    timeout_secs: Option<f64>,
+) -> Result<ServerSniffResult, UiError> {
+    tokio::task::spawn_blocking(move || sniff_server_blocking(host, port, password, timeout_secs))
+        .await
+        .map_err(|e| {
+            log_error!("sniff_server: task join error: {e}");
+            UiError {
+                name: "internal_error".into(),
+                message: format!("Internal error: {e}"),
+            }
+        })?
+}
+
 /// Probes a Vintage Story server to detect version, password status, etc.
 ///
 /// Two-step process:
 /// 1. Send wrong version → get server's real version + basic flags
 /// 2. Send correct version + password → get detailed auth/password/whitelist status
-#[tauri::command]
-pub fn sniff_server(
+fn sniff_server_blocking(
     host: String,
     port: Option<u16>,
     password: Option<String>,

--- a/src/components/cards/server.card.tsx
+++ b/src/components/cards/server.card.tsx
@@ -1,4 +1,4 @@
-import { DownloadCloudIcon, Lock, Pencil, Play, Star } from "lucide-react";
+import { DownloadCloudIcon, Lock, Pencil, Play, Star, Wifi, WifiOff } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Group } from "@/components/ui/group";
@@ -6,6 +6,7 @@ import { TooltipTrigger } from "@/components/ui/tooltip";
 import { rootTooltipHandle } from "@/handles";
 import { useDownloadVersion } from "@/hooks/use-download-version";
 import { useInstalledVersionNames } from "@/hooks/use-installed-versions";
+import { useServerStatus } from "@/hooks/use-server-status";
 import { cn } from "@/lib/utils";
 import { findInstallationForServer, useInstallations } from "@/stores/installations";
 import type { Server } from "@/stores/servers";
@@ -31,17 +32,38 @@ export function ServerCard({ server, onConnect, onUnfavorite, onEdit }: ServerCa
   const versions = useInstalledVersionNames();
 
   const { mutate: installVersion, isPending: isInstalling } = useDownloadVersion();
+  const { isChecking, isOnline } = useServerStatus(server);
 
   return (
     <>
       <div className="flex items-center gap-3">
-        <div
-          className={`size-2 rounded-full ${
-            installation && versions.includes(installation.version)
-              ? "bg-success"
-              : "bg-muted-foreground/40"
-          }`}
-        />
+        <div className="flex flex-col items-center gap-1.5">
+          <div
+            className={`size-2 rounded-full ${
+              installation && versions.includes(installation.version)
+                ? "bg-success"
+                : "bg-muted-foreground/40"
+            }`}
+            title={
+              installation && versions.includes(installation.version)
+                ? "Matching version installed"
+                : "Matching version not installed"
+            }
+          />
+          {isChecking ? (
+            <span title="Checking server status...">
+              <Wifi aria-hidden="true" className="text-muted-foreground/40 size-3" />
+            </span>
+          ) : isOnline ? (
+            <span title="Server is online">
+              <Wifi aria-hidden="true" className="text-success size-3" />
+            </span>
+          ) : (
+            <span title="Server is unreachable">
+              <WifiOff aria-hidden="true" className="text-destructive size-3" />
+            </span>
+          )}
+        </div>
         <div className="text-left">
           <p className="text-foreground font-mono text-sm">
             {server.name}

--- a/src/hooks/use-server-status.ts
+++ b/src/hooks/use-server-status.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+
+import type { Server } from "@/stores/servers";
+
+export const serverStatusQueryKey = (server: Pick<Server, "id">) =>
+  ["serverStatus", server.id] as const;
+
+/**
+ * Pings a saved server using the same handshake probe as the "Test Server"
+ * button, but with a short timeout tuned for a background reachability
+ * check rather than a full version/password sniff.
+ */
+export const useServerStatus = (server: Server) => {
+  const { isPending, isError } = useQuery({
+    queryFn: () =>
+      invoke("sniff_server", {
+        host: server.ip,
+        password: server.password || undefined,
+        port: server.port ?? undefined,
+        timeout_secs: 3,
+      }),
+    queryKey: serverStatusQueryKey(server),
+    retry: false,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    isChecking: isPending,
+    isOnline: !isPending && !isError,
+  };
+};


### PR DESCRIPTION
## Summary

Adds a live online/offline indicator for each saved server on the Home screen, using a background ping so users can tell at a glance whether a server is actually reachable before trying to connect — right now the only status shown is whether the matching game version is installed locally, which isn't the same thing.

## Changes

- Adds a `Wifi`/`WifiOff` icon beneath each server's existing version-match dot on the Home screen ([server.card.tsx](src/components/cards/server.card.tsx)), driven by a new `useServerStatus` hook ([use-server-status.ts](src/hooks/use-server-status.ts)) that pings the server using the same handshake probe already powering the "Test Server" button in the Add/Edit Server dialog, just with a shorter timeout (3s) suited to a background check.
- `sniff_server` is now `async` and runs its blocking socket I/O via `tokio::task::spawn_blocking` ([sniffer.rs](src-tauri/src/modules/sniffer.rs)). This was a necessary fix, not just cleanup: `sniff_server` was previously a plain synchronous command, and Tauri runs non-async commands on the main thread — so with a ping now firing automatically per server on every Home screen render, the app would freeze for the duration of each connection attempt. Confirmed fixed by rapidly switching between Home and another tab, which previously froze the whole app until the in-flight probe(s) resolved.
- No duplicate-ping concern on rapid remounts: TanStack Query dedupes by query key (`["serverStatus", server.id]`) regardless of component mount/unmount, so switching away and back while a check is still in flight re-subscribes to the same request rather than firing a new one.

## Related Issues

N/A — not filed as an issue beforehand.

## Screenshots / Demos (if applicable)
<img width="506" height="219" alt="image" src="https://github.com/user-attachments/assets/a6e827a2-d23c-44ae-931b-fd3f7deba83b" />

<img width="504" height="222" alt="image" src="https://github.com/user-attachments/assets/85d9fd87-e454-4b43-943c-3e3802e5ee7e" />

Home screen: each server row now shows a small green (online) or red (offline) Wifi icon directly under the existing version-match dot, with a hover tooltip. Gray/neutral while the check is still in progress.

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — see below
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`cargo fmt`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)
None for consumers of the app. Internally, `sniff_server`'s Rust signature changed from a plain `fn` to `async fn` — this only affects direct Rust callers, and it's a `#[tauri::command]` invoked exclusively over IPC (`invoke("sniff_server", ...)`), which already returns a `Promise` on the JS side either way, so the existing "Test Server" dialog call site required no changes.

## Additional Context
The freeze bug was found during manual testing of this feature, not present before it — `sniff_server` already existed and was already synchronous, but it was previously only triggered by an explicit user click (Test Server), so the main-thread blocking was brief and easy to miss. Making it fire automatically and repeatedly (once per saved server, on every Home render) surfaced the issue, so fixing it was folded into this PR rather than filed separately.

## Reviewers

@LovelessCodes