### PR TITLE
feat(mods): add relevance sort option to mod search

### DIFF
--- a/src/components/pages/mods-browser.tsx
+++ b/src/components/pages/mods-browser.tsx
@@ -32,7 +32,15 @@ export type OutputMod = {
   path: string;
 };
 
-type SortBy = "created" | "name" | "trending" | "downloads" | "follows" | "comments" | "updated";
+type SortBy =
+  | "relevance"
+  | "created"
+  | "name"
+  | "trending"
+  | "downloads"
+  | "follows"
+  | "comments"
+  | "updated";
 type OrderDirection = "ascending" | "descending";
 type Side = "any" | "client" | "server" | "both" | "installed";
 type Category = "mod" | "externaltool" | "other";
@@ -43,6 +51,7 @@ const sortOptions: Record<SortBy, string> = {
   downloads: "Downloads",
   follows: "Follows",
   name: "Name",
+  relevance: "Relevance",
   trending: "Trending",
   updated: "Last Updated",
 };
@@ -65,6 +74,18 @@ const modsQuery = (params: ModsParams) => ({
   refetchOnWindowFocus: false,
   staleTime: Infinity,
 });
+
+/** Ranks match quality: name starts-with > name contains > tag match > description match. */
+function relevanceRank(mod: Mod, query: string): number {
+  const q = stripped(query);
+  if (!q) return 4;
+  const name = stripped(mod.name);
+  if (name.startsWith(q)) return 0;
+  if (name.includes(q)) return 1;
+  if (mod.tags.some((tag) => stripped(tag).includes(q))) return 2;
+  if (stripped(mod.summary).includes(q)) return 3;
+  return 4;
+}
 
 export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
   // ── Local filter state (replaces zustand useModsFilters) ──
@@ -138,6 +159,17 @@ export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
         return true;
       })
       .sort((a, b) => {
+        if (sortBy === "relevance") {
+          const rankA = relevanceRank(a, searchText);
+          const rankB = relevanceRank(b, searchText);
+          if (rankA !== rankB) {
+            return orderDirection === "descending" ? rankB - rankA : rankA - rankB;
+          }
+          // Same relevance tier — break ties by trending points.
+          return orderDirection === "descending"
+            ? a.trendingpoints - b.trendingpoints
+            : b.trendingpoints - a.trendingpoints;
+        }
         if (sortBy === "name") {
           return orderDirection === "descending"
             ? stripped(b.name).localeCompare(stripped(a.name))
@@ -168,7 +200,17 @@ export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
         }
         return orderDirection === "descending" ? 0 : -1;
       });
-  }, [mods, selectedModTags, author, category, side, installedModIdSet, sortBy, orderDirection]);
+  }, [
+    mods,
+    selectedModTags,
+    author,
+    category,
+    side,
+    installedModIdSet,
+    sortBy,
+    orderDirection,
+    searchText,
+  ]);
 
   // ── Tag lookup tables for ModItem ──
   const tagColorMap = useMemo(() => {


### PR DESCRIPTION
## Summary

None of the existing sort options (Trending, Name, Downloads, etc.) ever factored the search text into ordering at all, so typing a mod's exact name wouldn't reliably surface it near the top of results. Adds a "Relevance" sort option that actually ranks results against what was typed.

## Changes

- Adds a `"relevance"` option to `SortBy` and the Sort by dropdown, labeled "Relevance".
- New `relevanceRank()` helper ([mods-browser.tsx](src/components/pages/mods-browser.tsx)) scores each mod against the current search text in tiers: name starts with the query → name contains it → a tag matches → the description matches. Lower tier = better match.
- Wired into the existing `.sort()` chain in `modsList`: mods in the same tier are broken by trending points, consistent with how the other numeric sorts already work.
- `searchText` added to the `useMemo` dependency array, since relevance ranking now depends on it (previously the memo only cared about sort/filter state, never the search text itself).
- Text matching goes through the existing `stripped()` utility (already used by the "Name" sort) for consistent, punctuation/case-insensitive comparison.

## Related Issues

N/A — found while investigating what looked like a sorting bug (mods disappearing when switching "Sort by"), but turned out to be a missing feature rather than a bug: no sort option had ever considered search relevance at all.

## Screenshots / Demos (if applicable)

<img width="1034" height="734" alt="image" src="https://github.com/user-attachments/assets/091be44d-0ba6-46e4-ab61-5cf14918bbfe" />

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — none; purely additive, default sort (`"trending"`) is unchanged
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)

None.

## Additional Context

"Relevance" is an added option, not the new default — `sortBy` still defaults to `"trending"`. Given the original motivation was "typing an exact name should surface it first," making Relevance the default is a reasonable follow-up if maintainers want that out-of-the-box behavior, but that's a more opinionated UX call than this PR aims to make on its own.

## Reviewers

@LovelessCodes