### PR TITLE
fix(mods): resolve actual latest release instead of trusting releases[0]

### DIFF
--- a/src/components/dialogs/addmod.dialog.tsx
+++ b/src/components/dialogs/addmod.dialog.tsx
@@ -12,7 +12,7 @@ import { useAddModToInstallation } from "@/hooks/use-add-mod-to-installation";
 import { installedModsQueryKey } from "@/hooks/use-installed-mods";
 import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import type { ModInfo, ProgressPayload, Release } from "@/lib/types";
-import { hashPath } from "@/lib/utils";
+import { hashPath, latestRelease } from "@/lib/utils";
 
 export type AddModDialogProps = {
   modid: number;
@@ -28,7 +28,7 @@ export function AddModDialog({ modid, modsDirectory }: AddModDialogProps) {
   });
   const listenRef = useRef<UnlistenFn>(null);
   const [userSelectedVersion, setUserSelectedVersion] = useState<Release | null>(null);
-  const selectedVersion = userSelectedVersion ?? modInfo?.mod.releases[0] ?? null;
+  const selectedVersion = userSelectedVersion ?? latestRelease(modInfo?.mod.releases) ?? null;
   const queryClient = useQueryClient();
   const pathHash = hashPath(modsDirectory);
   const { mutate: addModToInstallation } = useAddModToInstallation({

--- a/src/components/dialogs/standalone-install-picker.dialog.tsx
+++ b/src/components/dialogs/standalone-install-picker.dialog.tsx
@@ -13,7 +13,7 @@ import { useHostedServers } from "@/hooks/queries/server-hosting";
 import { installedModsQueryKey } from "@/hooks/use-installed-mods";
 import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import type { ModInfo, ProgressPayload, Release } from "@/lib/types";
-import { hashPath, pathDelimiter } from "@/lib/utils";
+import { hashPath, latestRelease, pathDelimiter } from "@/lib/utils";
 import { useInstallations } from "@/stores/installations";
 
 export type StandaloneInstallPickerProps = {
@@ -55,7 +55,7 @@ export function StandaloneInstallPickerDialog({ modid, mod }: StandaloneInstallP
 
   const [selectedDestination, setSelectedDestination] = useState<Destination | null>(null);
   const [userSelectedVersion, setUserSelectedVersion] = useState<Release | null>(null);
-  const selectedVersion = userSelectedVersion ?? modInfo?.mod.releases[0] ?? null;
+  const selectedVersion = userSelectedVersion ?? latestRelease(modInfo?.mod.releases) ?? null;
 
   const queryClient = useQueryClient();
   const listenRef = useRef<UnlistenFn>(null);

--- a/src/hooks/use-add-latest-mod-version.ts
+++ b/src/hooks/use-add-latest-mod-version.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 
 import type { Mod } from "@/components/lists/mod.list";
 import type { ModInfo, ProgressPayload } from "@/lib/types";
-import { hashPath, pathDelimiter } from "@/lib/utils";
+import { hashPath, latestRelease, pathDelimiter } from "@/lib/utils";
 
 import { installedModsQueryKey } from "./use-installed-mods";
 import { modUpdatesQueryKey } from "./use-mod-updates";
@@ -32,7 +32,7 @@ export const useAddLatestModVersion = ({
         destpath: path,
         emitevent,
         extract: false,
-        url: modInfo.mod.releases[0]?.mainfile,
+        url: latestRelease(modInfo.mod.releases)?.mainfile,
       })) as string;
       return { modInfo };
     },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,6 +44,16 @@ export function compareSemverAsc(a: string, b: string) {
   return pa - pb;
 }
 
+/** Finds the latest mod version — releases[] isn't guaranteed sorted by version. */
+export function latestRelease<T extends { modversion: string }>(
+  releases: T[] | undefined,
+): T | undefined {
+  if (!releases || releases.length === 0) return undefined;
+  return releases.reduce((latest, release) =>
+    compareSemverDesc(release.modversion, latest.modversion) < 0 ? release : latest,
+  );
+}
+
 export const zipfolderprefix = () => {
   const currentPlatform = platform();
   const pf = currentPlatform.charAt(0).toLowerCase();


### PR DESCRIPTION
## Summary

The mod API's `releases` array isn't guaranteed to be sorted by version. Upload order can diverge from version order (e.g. a pre-release uploaded after its own stable release). "Install latest version" and the mod-add dialogs all assumed `releases[0]` was the newest, so they could silently install an old version instead of the real latest. Found this while investigating a report that installing "Terra Prety" via "Install latest version" grabbed `6.2.0` instead of the actual latest, `7.10.2`.

## Changes

- Adds a shared `latestRelease()` helper ([lib/utils.ts](src/lib/utils.ts)) that compares every release's `modversion` via the existing `compareSemverDesc` comparator (already used elsewhere for version sorting) and returns the actual highest version, rather than trusting array position.
- Swaps all three `releases[0]` call sites to use it:
  - [use-add-latest-mod-version.ts](src/hooks/use-add-latest-mod-version.ts) — the actual "Install latest version" button
  - [addmod.dialog.tsx](src/components/dialogs/addmod.dialog.tsx)
  - [standalone-install-picker.dialog.tsx](src/components/dialogs/standalone-install-picker.dialog.tsx)
- In both dialogs, manual version selection (`userSelectedVersion`) still takes priority — `latestRelease()` is only the fallback default, same role `releases[0]` played before.
- Handles the empty-array edge case explicitly (`releases.length === 0` → `undefined`) since `Array.prototype.reduce` with no releases and no seed value throws, and the old `releases[0]` behavior returned `undefined` gracefully in that case — wanted to preserve that rather than introduce a new crash path.

## Related Issues

N/A 

## Screenshots / Demos (if applicable)

<img width="893" height="685" alt="Screenshot 2026-08-02 000532" src="https://github.com/user-attachments/assets/a702b470-04c8-421f-b902-fff1e588b939" />

<img width="1188" height="708" alt="Screenshot 2026-08-02 000801" src="https://github.com/user-attachments/assets/b85ac81f-0c68-4819-9e7f-e780fe38d702" />

To reproduce the original bug (before this fix) and verify: search for "Terra Prety" in Mods, use "Install latest version", it downloads `TerraPrety_6.2.0.zip` instead of the actual latest (`7.10.2` per [mods.vintagestory.at/terraprety](https://mods.vintagestory.at/terraprety#tab-files), where `7.0.5-pre.1` is uploaded after `7.0.5` itself, breaking the upload-order assumption).

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — see below
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)

None. Behavior is unchanged for any mod whose releases already happen to be array-ordered newest-first; it only differs (correctly) for mods like this one where upload order and version order diverge.

## Additional Context

N/A

## Reviewers

@LovelessCodes