### PR TITLE
fix(servers): persist server favorites across restarts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -273,6 +273,7 @@ pub fn run() {
             servers::add_server_to_installation,
             servers::remove_server_from_installation,
             servers::check_server_in_installation,
+            servers::set_server_favorite,
             // Saves
             saves::get_installation_saves,
             saves::get_all_saves,

--- a/src-tauri/src/modules/servers.rs
+++ b/src-tauri/src/modules/servers.rs
@@ -2,10 +2,11 @@ use reqwest::get;
 use serde::Serialize;
 use serde_json::{from_str, json, to_string_pretty, Map, Value};
 use std::{
+    collections::HashSet,
     fs::{read_dir, read_to_string, write},
     path::PathBuf,
 };
-use tauri::{command, AppHandle};
+use tauri::{command, AppHandle, Manager};
 
 use super::errors::UiError;
 use super::installations::find_installation_by_id;
@@ -21,6 +22,54 @@ pub struct SavedServer {
     pub password: String,
     pub installation_id: u64,
     pub installation_name: String,
+    pub favorite: bool,
+}
+
+// Tracked separately from clientsettings.json (shared with the game client),
+// keyed by the same id fetch_all_servers assigns.
+fn server_favorites_path(app: &AppHandle) -> Result<PathBuf, UiError> {
+    let dir = app.path().app_data_dir().map_err(|e| UiError {
+        name: "app_data_failed".into(),
+        message: format!("Failed to get app data dir: {e}"),
+    })?;
+    Ok(dir.join("server_favorites.json"))
+}
+
+fn read_server_favorites(app: &AppHandle) -> HashSet<u64> {
+    let path = match server_favorites_path(app) {
+        Ok(p) => p,
+        Err(_) => return HashSet::new(),
+    };
+    read_to_string(&path)
+        .ok()
+        .and_then(|content| from_str::<Vec<u64>>(&content).ok())
+        .map(|ids| ids.into_iter().collect())
+        .unwrap_or_default()
+}
+
+fn write_server_favorites(app: &AppHandle, favorites: &HashSet<u64>) -> Result<(), UiError> {
+    let path = server_favorites_path(app)?;
+    let ids: Vec<u64> = favorites.iter().copied().collect();
+    let content = to_string_pretty(&ids).map_err(|e| UiError {
+        name: "serialize_error".into(),
+        message: format!("Failed to serialize server favorites: {e}"),
+    })?;
+    write(&path, content).map_err(|e| UiError {
+        name: "io_error".into(),
+        message: format!("Failed to write server favorites: {e}"),
+    })
+}
+
+#[command]
+pub fn set_server_favorite(app: AppHandle, id: u64, favorite: bool) -> Result<(), UiError> {
+    log_info!("set_server_favorite: id={} favorite={}", id, favorite);
+    let mut favorites = read_server_favorites(&app);
+    if favorite {
+        favorites.insert(id);
+    } else {
+        favorites.remove(&id);
+    }
+    write_server_favorites(&app, &favorites)
 }
 
 fn parse_server_string(raw: &str) -> Option<(String, String, Option<u16>, String)> {
@@ -57,6 +106,7 @@ fn extract_servers_from_directory(
     dir: &PathBuf,
     installation_id: u64,
     installation_name: &str,
+    favorites: &HashSet<u64>,
 ) -> Vec<SavedServer> {
     let mut servers = Vec::new();
     let clientsettings_path = dir.join("clientsettings.json");
@@ -79,6 +129,7 @@ fn extract_servers_from_directory(
                                 password,
                                 installation_id,
                                 installation_name: installation_name.to_string(),
+                                favorite: favorites.contains(&id),
                             });
                         }
                     }
@@ -100,6 +151,8 @@ pub fn fetch_all_servers(app: AppHandle) -> Result<Vec<SavedServer>, UiError> {
         return Ok(all_servers);
     }
 
+    let favorites = read_server_favorites(&app);
+
     for entry in read_dir(&installations_dir).map_err(|e| UiError {
         name: "io_error".into(),
         message: format!("Failed to read installations dir: {e}"),
@@ -115,8 +168,21 @@ pub fn fetch_all_servers(app: AppHandle) -> Result<Vec<SavedServer>, UiError> {
         let dir_name = entry.file_name().to_string_lossy().to_string();
         // Get installation id from installation.json (same hash-based id)
         let inst_id = crate::modules::utils::generate_id(&dir_name);
-        let servers = extract_servers_from_directory(&dir, inst_id, &dir_name);
+        let servers = extract_servers_from_directory(&dir, inst_id, &dir_name, &favorites);
         all_servers.extend(servers);
+    }
+
+    // Prune favorites with no matching live server — catches removal from
+    // either StoryForge or direct edits to the game's own config/launcher.
+    let live_ids: HashSet<u64> = all_servers.iter().map(|s| s.id).collect();
+    if favorites.iter().any(|id| !live_ids.contains(id)) {
+        let pruned: HashSet<u64> = favorites.intersection(&live_ids).copied().collect();
+        if let Err(e) = write_server_favorites(&app, &pruned) {
+            log_error!(
+                "fetch_all_servers: failed to prune stale favorites: {}",
+                e.message
+            );
+        }
     }
 
     Ok(all_servers)

--- a/src/stores/servers.ts
+++ b/src/stores/servers.ts
@@ -33,6 +33,7 @@ type SavedServer = {
   password: string;
   installation_id: number;
   installation_name: string;
+  favorite: boolean;
 };
 
 export const useServerStore = create<ServerStore>()((set) => ({
@@ -62,7 +63,7 @@ export const useServerStore = create<ServerStore>()((set) => ({
             ip: r.ip,
             port: r.port,
             password: r.password,
-            favorite: existing?.favorite ?? false,
+            favorite: existing?.favorite ?? r.favorite ?? false,
             installationId: r.installation_id,
             installationName: r.installation_name,
           };
@@ -99,12 +100,18 @@ export const useServerStore = create<ServerStore>()((set) => ({
     }),
   servers: [],
   toggleFavorite: (id) =>
-    set((state) => ({
-      ...state,
-      servers: state.servers.map((server) =>
-        server.id === id ? { ...server, favorite: !server.favorite } : server,
-      ),
-    })),
+    set((state) => {
+      const server = state.servers.find((s) => s.id === id);
+      if (server) {
+        invoke("set_server_favorite", { favorite: !server.favorite, id }).catch((e) =>
+          console.error("Failed to save server favorite:", e),
+        );
+      }
+      return {
+        ...state,
+        servers: state.servers.map((s) => (s.id === id ? { ...s, favorite: !s.favorite } : s)),
+      };
+    }),
   updateServer: (updatedServer, cb) =>
     set((state) => {
       if (!state.servers.find((s) => s.id === updatedServer.id)) {


### PR DESCRIPTION
## Summary

Servers are parsed live from the game's own `clientsettings.json` on every load, which has no favorite field and shouldn't be extended with one (that file is shared with the actual game client). Favorite status was only ever kept in memory, so it silently reset to `false` on every restart. Installations didn't have this problem since `installation.json` is a file StoryForge fully owns.

## Changes

- Adds a separate `server_favorites.json` ([servers.rs](src-tauri/src/modules/servers.rs)) tracking favorited server IDs, fully owned by StoryForge and independent of the game's own config file.
- New `set_server_favorite` command to update it; `fetch_all_servers` now reads it and stamps `favorite: bool` onto every `SavedServer` it returns.
- [servers.ts](src/stores/servers.ts): `toggleFavorite` now actually persists via `set_server_favorite` instead of only updating in-memory zustand state, and `loadServers` reads the real persisted value instead of unconditionally defaulting to `false`.
- Also prunes favorites with no matching live server on every `fetch_all_servers` call, so removing a server via StoryForge's remove button *or* by editing the game's config directly clears its favorite rather than leaving a stale entry that silently reappears if the same server (same name/ip/port) is ever added back. This was a deliberate behavior choice: favorite status is tied to a server currently being in your list, not a permanent memory of its connection details.

## Related Issues

N/A — found and reproduced directly, not filed as an issue beforehand.

## Screenshots / Demos (if applicable)

N/A — no UI changes, same star icon and interaction. 

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — see below
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`cargo check`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)

None. `server_favorites.json` is a new file, created lazily on first use; nothing reads or migrates old state since none existed to begin with (favorites were never persisted before this).

## Additional Context

Server IDs are a hash of `name + ip + port`, not scoped to an installation so the same server appearing under two installations shares one favorite state, and pruning checks against the full live list across all installations, not just one. This matches how `toggleFavorite(id)` was already keyed before this change.

## Reviewers

@LovelessCodes