### PR TITLE
fix(servers): sort favorites first on the Servers page

### DIFF
--- a/src/components/pages/servers.tsx
+++ b/src/components/pages/servers.tsx
@@ -30,7 +30,10 @@ export function ServersPage() {
       <ScrollArea className="h-full px-2" scrollFade>
         <AnimatePresence>
           {servers
-            .sort((a, b) => a.index - b.index)
+            .sort((a, b) => {
+              if (a.favorite === b.favorite) return a.index - b.index;
+              return a.favorite ? -1 : 1;
+            })
             .map((server, index) => (
               <MotionServerContextMenu
                 animate="show"


### PR DESCRIPTION
## Summary

The Servers page sorted purely by index, ignoring favorite status, while the Home/Dashboard server list already sorted favorites first then by index. Same underlying data, inconsistent order depending on which page you viewed it from.

## Changes

- [servers.tsx](src/components/pages/servers.tsx) matches the Servers page's sort to Home's: favorites first, then by index within each group. Exact same logic already used in [dashboard.tsx](src/components/pages/dashboard.tsx), just applied here too.

## Related Issues

N/A — found while comparing the two server list views, not filed as an issue.

## Screenshots / Demos (if applicable)

<img width="772" height="464" alt="image" src="https://github.com/user-attachments/assets/acc33d9c-e000-4345-8aca-0eb94bbff3e1" />

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — see below
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)

None. Non-favorited servers keep their existing relative order (still sorted by `index` within that group). Only favorited servers move to the top, matching Home's existing behavior.

## Additional Context

One-line change, no new logic — just reusing the sort comparator that already existed on the Home page.

## Reviewers

@LovelessCodes