### PR TITLE
fix(installations): clear stale mod cache on delete and rename

### DIFF
--- a/src/components/dialogs/deleteinstallation.dialog.tsx
+++ b/src/components/dialogs/deleteinstallation.dialog.tsx
@@ -53,10 +53,6 @@ export function DeleteInstallationDialog({ installation }: DeleteInstallationDia
       if (data === "removed") {
         void queryClient.invalidateQueries({ queryKey: ["saves"] });
         void queryClient.invalidateQueries({ queryKey: ["saves", installation.id] });
-        // Installation paths are name-derived with no uniqueness suffix, so a
-        // new installation can reuse this exact path — without this, its
-        // stale "mods installed at this path" cache (staleTime: Infinity)
-        // would otherwise outlive the installation it described.
         queryClient.removeQueries({ queryKey: installedModsQueryKey(installation.path) });
         queryClient.removeQueries({ queryKey: modUpdatesQueryKey(installation.path) });
         removeInstallation(variables);

--- a/src/components/dialogs/deleteinstallation.dialog.tsx
+++ b/src/components/dialogs/deleteinstallation.dialog.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { rootAlertDialogHandle } from "@/handles";
+import { installedModsQueryKey } from "@/hooks/use-installed-mods";
+import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import { useSavesFromInstallation } from "@/hooks/use-saves";
 import { type Installation, useInstallations } from "@/stores/installations";
 import { useServerStore } from "@/stores/servers";
@@ -51,6 +53,12 @@ export function DeleteInstallationDialog({ installation }: DeleteInstallationDia
       if (data === "removed") {
         void queryClient.invalidateQueries({ queryKey: ["saves"] });
         void queryClient.invalidateQueries({ queryKey: ["saves", installation.id] });
+        // Installation paths are name-derived with no uniqueness suffix, so a
+        // new installation can reuse this exact path — without this, its
+        // stale "mods installed at this path" cache (staleTime: Infinity)
+        // would otherwise outlive the installation it described.
+        queryClient.removeQueries({ queryKey: installedModsQueryKey(installation.path) });
+        queryClient.removeQueries({ queryKey: modUpdatesQueryKey(installation.path) });
         removeInstallation(variables);
         toast.success("Installation deleted", {
           id: `installation-delete-${variables}`,

--- a/src/components/dialogs/installation.dialog.tsx
+++ b/src/components/dialogs/installation.dialog.tsx
@@ -18,10 +18,12 @@ import { TooltipTrigger } from "@/components/ui/tooltip";
 import { rootDialogHandle, rootTooltipHandle } from "@/handles";
 import { useAppFolder } from "@/hooks/use-app-folder";
 import { useDownloadVersion } from "@/hooks/use-download-version";
+import { installedModsQueryKey } from "@/hooks/use-installed-mods";
 import {
   installedVersionsQueryKey,
   useInstalledVersionNames,
 } from "@/hooks/use-installed-versions";
+import { modUpdatesQueryKey } from "@/hooks/use-mod-updates";
 import { logToFile } from "@/lib/logger";
 import { gameVersionsQuery } from "@/lib/queries";
 import { buildInstallationPath, compareSemverDesc, makeStringFolderSafe } from "@/lib/utils";
@@ -169,6 +171,11 @@ export function InstallationDialog({ installation, version }: InstallationDialog
                   source: installationsParent ?? appFolder ?? "",
                   subdir: oldSafeName,
                 });
+                // The old path's mod cache (staleTime: Infinity) would otherwise
+                // outlive this installation, same as on delete — a later
+                // installation reusing the old name would inherit stale data.
+                queryClient.removeQueries({ queryKey: installedModsQueryKey(installation.path) });
+                queryClient.removeQueries({ queryKey: modUpdatesQueryKey(installation.path) });
               }
               await saveInstallationToDisk({
                 envVars: Object.fromEntries(

--- a/src/components/dialogs/installation.dialog.tsx
+++ b/src/components/dialogs/installation.dialog.tsx
@@ -171,9 +171,6 @@ export function InstallationDialog({ installation, version }: InstallationDialog
                   source: installationsParent ?? appFolder ?? "",
                   subdir: oldSafeName,
                 });
-                // The old path's mod cache (staleTime: Infinity) would otherwise
-                // outlive this installation, same as on delete — a later
-                // installation reusing the old name would inherit stale data.
                 queryClient.removeQueries({ queryKey: installedModsQueryKey(installation.path) });
                 queryClient.removeQueries({ queryKey: modUpdatesQueryKey(installation.path) });
               }


### PR DESCRIPTION
## Summary

Installation paths are name-derived with no uniqueness suffix, so a later installation can reuse an earlier one's exact path. The mods cache for that path (`useInstalledMods`/`useModUpdates`, `staleTime: Infinity`) never expires and was never cleared, so the new installation would silently inherit stale "mods installed here" data. The Add Mod flow would then think an already-latest version was present and offer alternate versions instead of letting it download.

## Changes

- Clears both caches for the abandoned path in two places:
  - [deleteinstallation.dialog.tsx](src/components/dialogs/deleteinstallation.dialog.tsx) on full deletion.
  - [installation.dialog.tsx](src/components/dialogs/installation.dialog.tsx) on rename, which orphans a path the exact same way a delete does, just without ever calling the delete command. This was found via testing: an initial version of this fix only handled deletion, and renaming before deleting reproduced the same stale-cache symptom through a path the first fix never touched.
- Uses `removeQueries` rather than `invalidateQueries` in both spots. The old path's data is genuinely gone, not just possibly stale, and this avoids `keepPreviousData` momentarily surfacing it again if the path gets reused before a fresh fetch resolves.

## Related Issues

N/A

## Screenshots / Demos (if applicable)

No UI changes.

## Checklist

- [x] I have linked related issues using #<number> — N/A, see above
- [x] I have updated documentation where appropriate — no docs affected
- [x] I have verified backward compatibility or noted breaking changes — see below
- [x] I have run linters/formatters and addressed warnings — `oxfmt`/`oxlint`/`tsc --noEmit` all pass clean

## Breaking Changes (if any)

None.

## Repro steps (pre-fix)

Checkout `release` before this PR's commit (or just check out the parent commit) to verify against the broken behavior.

### Scenario A — straightforward delete + recreate

1. **Installations** → **Add Installation** → name it `Test`, pick any game version, create it.
2. Open `Test` → **Mods** tab → **Add mod** → search for any mod (e.g. "BetterRuins") → install it.
3. Confirm it now shows as installed for `Test`.
4. Go back to **Installations**, delete `Test` (confirm the delete dialog).
5. **Add Installation** again → name it `Test` (same name as before) → create it.
6. Open the new `Test` → **Mods** tab → search for the same mod.

**Broken (pre-fix):** the mod's version picker shows it as already installed at the latest version and offers alternate/older versions instead of letting you install the latest — even though this is a brand-new installation with an empty `Mods` folder on disk.
**Expected (post-fix):** the mod shows as not installed, and installing it downloads normally.

### Scenario B — rename before delete (the gap the first version of this fix missed)

1. **Installations** → **Add Installation** → name it `BugTest` → create it.
2. Open `BugTest` → **Mods** tab → install a mod (e.g. "BetterRuins").
3. Edit `BugTest` → rename it to `BugTest123` → save.
4. Delete `BugTest123`.
5. **Add Installation** again → name it `BugTest` (the *original* name, not `BugTest123`) → create it.
6. Open the new `BugTest` → **Mods** tab → search for the same mod.

**Broken (pre-fix):** same symptom as Scenario A — the mod incorrectly shows as already installed. This path specifically confirms the rename case, since deletion only ever touched `BugTest123`'s cache, never the original `BugTest` path abandoned at the rename step.
**Expected (post-fix):** the mod shows as not installed.

## Reviewers

@LovelessCodes (CODEOWNERS)