### PR TITLE
fix(mods): rank exact name matches above longer partial matches

### DIFF
--- a/src/components/pages/mods-browser.tsx
+++ b/src/components/pages/mods-browser.tsx
@@ -75,16 +75,17 @@ const modsQuery = (params: ModsParams) => ({
   staleTime: Infinity,
 });
 
-/** Ranks match quality: name starts-with > name contains > tag match > description match. */
+/** Ranks match quality: exact name > name starts-with > name contains > tag match > description match. */
 function relevanceRank(mod: Mod, query: string): number {
   const q = stripped(query);
-  if (!q) return 4;
+  if (!q) return 5;
   const name = stripped(mod.name);
-  if (name.startsWith(q)) return 0;
-  if (name.includes(q)) return 1;
-  if (mod.tags.some((tag) => stripped(tag).includes(q))) return 2;
-  if (stripped(mod.summary).includes(q)) return 3;
-  return 4;
+  if (name === q) return 0;
+  if (name.startsWith(q)) return 1;
+  if (name.includes(q)) return 2;
+  if (mod.tags.some((tag) => stripped(tag).includes(q))) return 3;
+  if (stripped(mod.summary).includes(q)) return 4;
+  return 5;
 }
 
 export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
@@ -166,6 +167,10 @@ export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
             return orderDirection === "descending" ? rankB - rankA : rankA - rankB;
           }
           // Same relevance tier — break ties by trending points.
+          const lengthDiff = stripped(a.name).length - stripped(b.name).length;
+          if (lengthDiff !== 0) {
+            return orderDirection === "descending" ? -lengthDiff : lengthDiff;
+          }
           return orderDirection === "descending"
             ? a.trendingpoints - b.trendingpoints
             : b.trendingpoints - a.trendingpoints;


### PR DESCRIPTION
## Summary

Exact name matches (e.g. "BetterRuins") could rank below longer partial matches (e.g. "BetterRuins Blueprint Tweaks") in Relevance sort, since both only counted as "starts with" and ties fell back to trending points, unrelated to how well the name actually matches.

## Changes

- Added an exact-match tier above "starts with" in `relevanceRank`.
- Ties within a tier now break by name length (shorter = closer match) before falling back to trending points.

## Related Issues

N/A

## Screenshots / Demos (if applicable)

### Before
<img width="1218" height="734" alt="image" src="https://github.com/user-attachments/assets/68aecef1-6d6c-4681-9f13-2f7505e43339" />

### After
<img width="1219" height="731" alt="image" src="https://github.com/user-attachments/assets/2d577bd3-acbf-4e09-aa69-9a90f7ffe1f4" />


## Checklist

- [x] I have linked related issues using #<number> — N/A
- [x] I have updated documentation where appropriate — none needed
- [x] I have verified backward compatibility or noted breaking changes — none
- [x] I have run linters/formatters and addressed warnings — clean

## Breaking Changes (if any)

None.

## Additional Context

Follow-up to the original Relevance sort PR.

## Reviewers

@LovelessCodes