### PR TITLE
feat(settings): add default mod sort preference

### DIFF
--- a/src/components/pages/mods-browser.tsx
+++ b/src/components/pages/mods-browser.tsx
@@ -23,6 +23,7 @@ import { useModUpdates } from "@/hooks/use-mod-updates";
 import { gameVersionsQuery, modTagsQuery } from "@/lib/queries";
 import type { ModTag } from "@/lib/types";
 import { cn, compareSemverDesc, stripped } from "@/lib/utils";
+import { useSettingsStore } from "@/stores/settings";
 
 export type OutputMod = {
   modid: number;
@@ -32,7 +33,7 @@ export type OutputMod = {
   path: string;
 };
 
-type SortBy =
+export type SortBy =
   | "relevance"
   | "created"
   | "name"
@@ -45,7 +46,7 @@ type OrderDirection = "ascending" | "descending";
 type Side = "any" | "client" | "server" | "both" | "installed";
 type Category = "mod" | "externaltool" | "other";
 
-const sortOptions: Record<SortBy, string> = {
+export const sortOptions: Record<SortBy, string> = {
   comments: "Comments",
   created: "Created",
   downloads: "Downloads",
@@ -92,7 +93,8 @@ export function ModBrowser({ modsDirectory }: { modsDirectory?: string }) {
   const [searchText, setSearchText] = useState("");
   const [selectedModTags, setSelectedModTags] = useState<ModTag[]>([]);
   const [selectedGameVersions, setSelectedGameVersions] = useState<string[]>([]);
-  const [sortBy, setSortBy] = useState<SortBy>("trending");
+  const defaultModSortBy = useSettingsStore((state) => state.defaultModSortBy);
+  const [sortBy, setSortBy] = useState<SortBy>(defaultModSortBy);
   const [orderDirection, setOrderDirection] = useState<OrderDirection>("ascending");
   const [author, setAuthor] = useState("");
   const [side, setSide] = useState<Side>("any");

--- a/src/components/pages/settings.tsx
+++ b/src/components/pages/settings.tsx
@@ -7,6 +7,7 @@ import z from "zod";
 
 import { AccountSettings } from "@/components/account-settings";
 import { LogViewer } from "@/components/log-viewer";
+import { type SortBy, sortOptions } from "@/components/pages/mods-browser";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -19,6 +20,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@/components/ui/tabs";
 import { TooltipTrigger } from "@/components/ui/tooltip";
 import { rootTooltipHandle } from "@/handles";
@@ -29,8 +31,11 @@ import { cn } from "@/lib/utils";
 import { useInstallationsStore } from "@/stores/installations";
 import { type SetParentConfigProps, useSettingsStore } from "@/stores/settings";
 
+const sortByValues = Object.keys(sortOptions) as [SortBy, ...SortBy[]];
+
 const settingsSchema = z.object({
   darkMode: z.boolean(),
+  defaultModSortBy: z.enum(sortByValues),
   installationsParent: z.string().nullable(),
   streamMode: z.boolean(),
   useSystemDotnet: z.boolean(),
@@ -175,6 +180,7 @@ export function SettingsPage() {
   const form = useForm({
     defaultValues: {
       darkMode: settingsStore.darkMode,
+      defaultModSortBy: settingsStore.defaultModSortBy,
       installationsParent: settingsStore.installationsParent,
       streamMode: settingsStore.streamMode,
       useSystemDotnet: settingsStore.useSystemDotnet,
@@ -213,6 +219,9 @@ export function SettingsPage() {
       }
       if (value.streamMode !== settingsStore.streamMode) {
         settingsStore.toggleStreamMode();
+      }
+      if (value.defaultModSortBy !== settingsStore.defaultModSortBy) {
+        settingsStore.setDefaultModSortBy(value.defaultModSortBy);
       }
       if (value.useSystemDotnet !== settingsStore.useSystemDotnet) {
         settingsStore.toggleUseSystemDotnet();
@@ -469,6 +478,26 @@ export function SettingsPage() {
                     When enabled, the app will try to use your system's .NET runtime before
                     downloading its own.
                   </p>
+                </div>
+              )}
+            </form.Field>
+            <form.Field name="defaultModSortBy">
+              {(field) => (
+                <div className="grid gap-2">
+                  <Label>Default Mod Sort</Label>
+                  <Select
+                    onValueChange={(value) => field.handleChange(value as SortBy)}
+                    value={field.state.value}
+                  >
+                    <SelectTrigger>{sortOptions[field.state.value]}</SelectTrigger>
+                    <SelectContent align="start" alignItemWithTrigger={false}>
+                      {Object.entries(sortOptions).map(([key, value]) => (
+                        <SelectItem key={key} value={key}>
+                          {value}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               )}
             </form.Field>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -3,6 +3,7 @@ import { appDataDir } from "@tauri-apps/api/path";
 import { createTauriStore } from "@tauri-store/zustand";
 import { create } from "zustand";
 
+import type { SortBy } from "@/components/pages/mods-browser";
 import { logToFile } from "@/lib/logger";
 
 export type SetParentConfigProps = {
@@ -13,6 +14,8 @@ export type SetParentConfigProps = {
 type SettingsStore = {
   darkMode: boolean;
   toggleDarkMode: () => void;
+  defaultModSortBy: SortBy;
+  setDefaultModSortBy: (sortBy: SortBy) => void;
   installationsParent: string | null;
   installationsSubdir: string;
   setInstallationsParent: (path: string | null, config?: SetParentConfigProps) => Promise<void>;
@@ -27,6 +30,8 @@ type SettingsStore = {
 
 export const useSettingsStore = create<SettingsStore>()((set, _get, store) => ({
   darkMode: window.matchMedia?.("(prefers-color-scheme: dark)").matches,
+  defaultModSortBy: "trending",
+  setDefaultModSortBy: (sortBy) => set(() => ({ defaultModSortBy: sortBy })),
   installationsParent: null,
   installationsSubdir: "installations",
   setInstallationsParent: async (path, config) => {


### PR DESCRIPTION
## Summary

Adds a persisted "Default Mod Sort" preference in Settings, so the Mods page opens with the user's preferred sort instead of always defaulting to "Trending".

## Changes

- Added `defaultModSortBy` (persisted, defaults to `"trending"`) and its setter to the settings store.
- Added a "Default Mod Sort" dropdown to the Settings page (Client tab).
- Mods page now seeds its `sortBy` state from this setting instead of a hardcoded value.

## Related Issues

N/A

## Screenshots / Demos (if applicable)

<img width="1007" height="494" alt="image" src="https://github.com/user-attachments/assets/e472f926-e608-4c3f-ad5c-04f19bf360be" />

## Checklist

- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Breaking Changes (if any)

None. Default value (`"trending"`) matches the previous hardcoded default, so existing users see no change until they set a preference.

## Additional Context

N/A

## Reviewers

@LovelessCodes 