### PR TITLE
fix(windows): hide native titlebar on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,7 +176,7 @@ pub fn run() {
                 .title("Story Forge")
                 .inner_size(800.0, 600.0)
                 .transparent(cfg!(target_os = "macos"))
-                .decorations(!cfg!(target_os = "linux"));
+                .decorations(cfg!(target_os = "macos"));
 
             let window = match win_builder.build() {
                 Ok(w) => {
@@ -211,7 +211,14 @@ pub fn run() {
             modules::logger::mark_webview_start();
             Ok(())
         })
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        & !tauri_plugin_window_state::StateFlags::DECORATIONS,
+                )
+                .build(),
+        )
         .invoke_handler(tauri::generate_handler![
             is_flatpak_cmd,
             // Authorization


### PR DESCRIPTION
## Summary

Fixes a duplicate titlebar on Windows: the native OS titlebar was showing alongside the app's own custom-drawn titlebar/window controls.

## Changes

- Disabled native window decorations on Windows (previously only Linux had them off).
- Excluded `DECORATIONS` from `tauri-plugin-window-state`'s tracked flags. It defaults to persisting/restoring decoration state per-window, which silently overrode the builder setting on subsequent launches.

## Related Issues

Closes [#166](https://github.com/LovelessCodes/StoryForge/issues/166)

## Screenshots / Demos (if applicable)

### Windows 11
<img width="1218" height="727" alt="image" src="https://github.com/user-attachments/assets/5df3f8d7-b90c-4e41-8d0e-c767922d158b" />

## Checklist

- [x] I have linked related issues using #<number>
- [x] I have updated documentation where appropriate
- [x] I have verified backward compatibility or noted breaking changes
- [x] I have run linters/formatters and addressed warnings

## Breaking Changes (if any)

**Please test this on MacOS/Linux as I do not have them available currently.**

## Additional Context

Existing users have a `.window-state.json` with `decorated: true` saved from before this fix. Without the plugin flag change, that stale value would keep overriding the new decorations setting on every launch, so both changes are required together.

## Reviewers

@LovelessCodes